### PR TITLE
fix: sync project editor ui with store updates

### DIFF
--- a/apps/project-editor/README.md
+++ b/apps/project-editor/README.md
@@ -1,0 +1,119 @@
+# Editor de Proyectos local
+
+Aplicación React + TypeScript para planificar eventos sin backend. Todo se ejecuta en el navegador: se puede crear un proyecto, definir horarios para cliente y staff, gestionar materiales, visualizar resultados en Gantt, obtener agregados y simular el desplazamiento en un mapa estilizado. El estado se guarda automáticamente en `localStorage` y se puede importar/exportar mediante archivos `*.eventplan.json`.
+
+## Requisitos
+
+- Node.js 18 o superior
+- npm 9 o superior
+
+## Scripts principales
+
+Todos los comandos se ejecutan dentro de `apps/project-editor/`:
+
+```bash
+npm install       # instala dependencias
+npm run dev       # modo desarrollo (Vite)
+npm run build     # genera build de producción
+npm run start     # sirve la build generada (vite preview)
+npm run validate  # typecheck + tests (unitarios + UI feliz)
+```
+
+## Flujo básico
+
+1. Inicia la app (`npm run dev`) y abre el asistente.
+2. Crea un proyecto nuevo, define nombre, fechas y datos de cliente.
+3. Desde el paso **Cliente**, fija hora inicial y usa los botones `+5/+15/+30/+60` para generar segmentos consecutivos. Puedes crear ubicaciones, tareas y materiales al vuelo.
+4. En **Staff** añade miembros y configura su propio horario (indicador de completo/incompleto).
+5. En **Resultados**:
+   - **Horarios**: vista Gantt filtrable y con zoom (`+`/`-`).
+   - **Materiales**: tabla agregada con exportación CSV.
+   - **Mapa**: simulación temporal con Play/Pausa (`Espacio`), velocidades 0.5×-4×, saltos ±5/±15 y "Ir a hora".
+6. Usa el menú superior para **Nuevo**, **Abrir…** (`*.eventplan.json`) y **Guardar como…** (descarga del JSON validado). Atajos: `Ctrl+N`, `Ctrl+O`, `Ctrl+S`.
+
+## Formato `*.eventplan.json`
+
+El esquema está validado con [Zod](https://zod.dev) (`src/domain/types.ts`). Ejemplo recortado:
+
+```json
+{
+  "id": "proj-123",
+  "schemaVersion": 1,
+  "nombre": "Evento Demo",
+  "notas": "Checklist en Drive",
+  "fechas": {
+    "inicio": "2024-07-12T00:00:00.000Z",
+    "fin": "2024-07-15T23:59:00.000Z"
+  },
+  "ubicaciones": [
+    { "id": "loc-1", "nombre": "Hotel Centro", "lat": 40.4168, "lng": -3.7038 }
+  ],
+  "cliente": { "id": "cli-1", "nombre": "Ana Pérez", "rol": "CLIENTE" },
+  "staff": [
+    { "id": "team-1", "nombre": "Luis", "rol": "STAFF", "email": "luis@example.com" }
+  ],
+  "materiales": [
+    { "id": "mat-1", "nombre": "Sillas plegables", "unidad": "unidad" }
+  ],
+  "tareas": [
+    {
+      "id": "task-1",
+      "nombre": "Montaje",
+      "requiereSubtareas": true,
+      "defaultMaterials": [
+        { "materialId": "mat-1", "cantidad": 10 }
+      ]
+    }
+  ],
+  "sesiones": [
+    {
+      "id": "sess-1",
+      "ownerId": "cli-1",
+      "ownerRol": "CLIENTE",
+      "inicioISO": "2024-07-12T08:00:00.000Z",
+      "finISO": "2024-07-12T08:30:00.000Z",
+      "locationId": "loc-1",
+      "tareaId": "task-1",
+      "materiales": [ { "materialId": "mat-1", "cantidad": 4 } ]
+    }
+  ],
+  "creadoAt": "2024-06-01T10:00:00.000Z",
+  "actualizadoAt": "2024-06-01T10:00:00.000Z"
+}
+```
+
+La importación valida el archivo completo; cualquier inconsistencia (IDs faltantes, tipos erróneos, versión distinta) lanza un mensaje en pantalla y se aborta la carga.
+
+## Adaptadores reemplazables
+
+Para facilitar cambios tecnológicos futuros, las integraciones externas están encapsuladas en `src/adapters/`:
+
+| Adaptador | Propósito | Cómo sustituir |
+|-----------|-----------|----------------|
+| `adapters/state/store.ts` | Crea el store (Zustand). | Cambia la implementación por otra librería conservando la misma API (`createStore`). |
+| `adapters/datetime/index.ts` | Utilidades basadas en `date-fns`. | Exporta las funciones con la firma actual usando otra librería o APIs nativas. |
+| `adapters/uuid/index.ts` | Generador de IDs (`crypto.randomUUID`). | Sustituye por `nanoid`, `uuid`, etc. |
+| `adapters/file/download.ts` / `upload.ts` | Descarga y selección de archivos. | Reemplaza por APIs nativas/terceros manteniendo la promesa/función. |
+| `adapters/storage/local.ts` | Lectura/escritura de autosave. | Cambia el mecanismo de persistencia (IndexedDB, file system) sin tocar el resto del código. |
+
+## Tests
+
+- **Core**: validan detección de solapes, agregación de materiales y serialización exacta.
+- **UI**: un test feliz recorre el asistente completo y comprueba que el JSON se exporta.
+
+Ejecuta todo con `npm run validate`.
+
+## Capturas / diagramas
+
+Las vistas principales se documentan en `/docs`:
+
+- ![Asistente paso a paso](docs/wizard.svg)
+- ![Vista Gantt](docs/gantt.svg)
+- ![Simulación en mapa](docs/map.svg)
+- ![Flujo de importación/exportación](docs/export.svg)
+
+## Limitaciones conocidas
+
+- El mapa usa una proyección simple (normaliza lat/lng o genera una cuadrícula cartesiana si faltan coordenadas).
+- Las confirmaciones de creación rápida utilizan `window.prompt`. Para experiencias más ricas puede integrarse un sistema de formularios modal.
+- No hay control de versiones sobre el autosave (solo se guarda el último estado). Se puede ampliar el adapter de `storage` para mantener historial.

--- a/apps/project-editor/docs/export.svg
+++ b/apps/project-editor/docs/export.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 360">
+  <rect width="640" height="360" fill="#ffffff" stroke="#143d59" stroke-width="4" />
+  <text x="320" y="44" text-anchor="middle" font-size="28" fill="#143d59">Flujo de importación y exportación</text>
+  <rect x="120" y="120" width="160" height="100" rx="12" fill="#d6e4f0" />
+  <text x="200" y="150" text-anchor="middle" font-size="18" fill="#143d59">Abrir…</text>
+  <text x="200" y="180" text-anchor="middle" font-size="14" fill="#4a7089">Cargar .eventplan.json</text>
+  <rect x="360" y="120" width="160" height="100" rx="12" fill="#1b76d2" opacity="0.9" />
+  <text x="440" y="150" text-anchor="middle" font-size="18" fill="#ffffff">Guardar como…</text>
+  <text x="440" y="180" text-anchor="middle" font-size="14" fill="#f1f6fb">Descargar JSON validado</text>
+  <polygon points="280,170 360,170 360,180 280,180" fill="#143d59" />
+  <text x="320" y="240" text-anchor="middle" font-size="14" fill="#4a7089">Autosave continuo en localStorage</text>
+</svg>

--- a/apps/project-editor/docs/gantt.svg
+++ b/apps/project-editor/docs/gantt.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 360">
+  <rect width="640" height="360" fill="#ffffff" stroke="#143d59" stroke-width="4" />
+  <text x="320" y="36" text-anchor="middle" font-size="28" fill="#143d59">Vista de horarios tipo Gantt</text>
+  <line x1="100" y1="90" x2="560" y2="90" stroke="#9ec1e6" stroke-width="2" stroke-dasharray="6 6" />
+  <line x1="100" y1="150" x2="560" y2="150" stroke="#9ec1e6" stroke-width="2" stroke-dasharray="6 6" />
+  <line x1="100" y1="210" x2="560" y2="210" stroke="#9ec1e6" stroke-width="2" stroke-dasharray="6 6" />
+  <text x="60" y="95" font-size="16" fill="#143d59" text-anchor="end">Cliente</text>
+  <text x="60" y="155" font-size="16" fill="#143d59" text-anchor="end">Staff 1</text>
+  <text x="60" y="215" font-size="16" fill="#143d59" text-anchor="end">Staff 2</text>
+  <rect x="120" y="75" width="180" height="30" rx="6" fill="#1b76d2" opacity="0.85" />
+  <text x="210" y="95" font-size="14" fill="#ffffff" text-anchor="middle">Reunión inicial</text>
+  <rect x="320" y="135" width="150" height="30" rx="6" fill="#f29f05" opacity="0.85" />
+  <text x="395" y="155" font-size="14" fill="#ffffff" text-anchor="middle">Montaje</text>
+  <rect x="260" y="195" width="220" height="30" rx="6" fill="#17a398" opacity="0.85" />
+  <text x="370" y="215" font-size="14" fill="#ffffff" text-anchor="middle">Prueba de sonido</text>
+  <text x="120" y="280" font-size="14" fill="#4a7089">Filtros por persona · Zoom con atajos + / -</text>
+</svg>

--- a/apps/project-editor/docs/map.svg
+++ b/apps/project-editor/docs/map.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 360">
+  <rect width="640" height="360" fill="#eef5fb" stroke="#143d59" stroke-width="4" />
+  <text x="320" y="36" text-anchor="middle" font-size="28" fill="#143d59">Simulación temporal en mapa</text>
+  <circle cx="180" cy="180" r="12" fill="#143d59" />
+  <text x="180" y="160" text-anchor="middle" font-size="16" fill="#143d59">Hotel</text>
+  <circle cx="440" cy="140" r="12" fill="#143d59" />
+  <text x="440" y="120" text-anchor="middle" font-size="16" fill="#143d59">Venue</text>
+  <circle cx="360" cy="260" r="12" fill="#143d59" />
+  <text x="360" y="240" text-anchor="middle" font-size="16" fill="#143d59">Oficinas</text>
+  <circle cx="200" cy="200" r="16" fill="#d23f3f" opacity="0.85" />
+  <text x="200" y="230" text-anchor="middle" font-size="16" fill="#d23f3f">Cliente</text>
+  <circle cx="400" cy="150" r="16" fill="#1b76d2" opacity="0.85" />
+  <text x="400" y="180" text-anchor="middle" font-size="16" fill="#1b76d2">Staff</text>
+  <text x="320" y="320" text-anchor="middle" font-size="14" fill="#4a7089">Controles: Play/Pausa · velocidades 0.5× a 4× · saltos ±5 / ±15 min · Ir a hora</text>
+</svg>

--- a/apps/project-editor/docs/wizard.svg
+++ b/apps/project-editor/docs/wizard.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 360">
+  <rect width="640" height="360" fill="#f8fbff" stroke="#143d59" stroke-width="4" />
+  <text x="320" y="40" text-anchor="middle" font-size="28" fill="#143d59">Asistente paso a paso</text>
+  <rect x="60" y="80" width="520" height="60" rx="12" fill="#d6e4f0" />
+  <text x="120" y="118" font-size="20" fill="#143d59">Proyecto</text>
+  <rect x="200" y="92" width="90" height="36" rx="8" fill="#143d59" />
+  <text x="245" y="116" font-size="18" text-anchor="middle" fill="#ffffff">Cliente</text>
+  <rect x="320" y="92" width="90" height="36" rx="8" fill="#d6e4f0" />
+  <text x="365" y="116" font-size="18" text-anchor="middle" fill="#143d59">Staff</text>
+  <rect x="440" y="92" width="110" height="36" rx="8" fill="#d6e4f0" />
+  <text x="495" y="116" font-size="18" text-anchor="middle" fill="#143d59">Resultados</text>
+  <rect x="100" y="180" width="440" height="140" rx="18" fill="#ffffff" stroke="#d6e4f0" stroke-width="3" />
+  <text x="320" y="220" text-anchor="middle" font-size="20" fill="#143d59">Formulario de proyecto con validaciones en línea</text>
+  <text x="320" y="250" text-anchor="middle" font-size="16" fill="#4a7089">Nombre, notas, fechas y datos del cliente</text>
+</svg>

--- a/apps/project-editor/index.html
+++ b/apps/project-editor/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Editor de Proyectos</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/project-editor/package-lock.json
+++ b/apps/project-editor/package-lock.json
@@ -1,0 +1,32 @@
+{
+  "name": "project-editor",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "project-editor",
+      "version": "0.1.0",
+      "license": "UNLICENSED",
+      "dependencies": {
+        "date-fns": "^3.6.0",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1",
+        "zustand": "^4.5.2",
+        "zod": "^3.23.8"
+      },
+      "devDependencies": {
+        "@testing-library/jest-dom": "^6.4.2",
+        "@testing-library/react": "^14.3.1",
+        "@testing-library/user-event": "^14.5.1",
+        "@types/react": "^18.3.5",
+        "@types/react-dom": "^18.3.2",
+        "@vitejs/plugin-react": "^4.3.1",
+        "jsdom": "^24.1.0",
+        "typescript": "^5.6.3",
+        "vite": "^5.3.4",
+        "vitest": "^1.6.0"
+      }
+    }
+  }
+}

--- a/apps/project-editor/package.json
+++ b/apps/project-editor/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "project-editor",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "start": "vite preview",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:ui": "vitest run --dir src/components/__tests__",
+    "validate": "npm run typecheck && npm run test"
+  },
+  "dependencies": {
+    "date-fns": "^3.6.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "zustand": "^4.5.2",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.4.2",
+    "@testing-library/react": "^14.3.1",
+    "@testing-library/user-event": "^14.5.1",
+    "@types/react": "^18.3.5",
+    "@types/react-dom": "^18.3.2",
+    "@vitejs/plugin-react": "^4.3.1",
+    "jsdom": "^24.1.0",
+    "typescript": "^5.6.3",
+    "vite": "^5.3.4",
+    "vitest": "^1.6.0"
+  }
+}

--- a/apps/project-editor/src/App.css
+++ b/apps/project-editor/src/App.css
@@ -1,0 +1,326 @@
+:root {
+  color-scheme: light dark;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  line-height: 1.4;
+}
+
+body {
+  margin: 0;
+  background-color: #f5f5f5;
+  color: #222;
+}
+
+a {
+  color: inherit;
+}
+
+button {
+  cursor: pointer;
+}
+
+.app-shell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.app-header {
+  background: #143d59;
+  color: #fff;
+  padding: 1rem;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 1rem;
+}
+
+.app-header h1 {
+  margin: 0;
+  font-size: 1.4rem;
+}
+
+.app-main {
+  flex: 1;
+  padding: 1rem;
+}
+
+.card {
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
+  padding: 1rem;
+}
+
+.grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.grid.two {
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.tab-bar {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.tab-button {
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 8px;
+  background: #ddd;
+}
+
+.tab-button.active {
+  background: #143d59;
+  color: #fff;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.table th,
+.table td {
+  border: 1px solid #ccc;
+  padding: 0.5rem;
+  text-align: left;
+}
+
+.badge {
+  display: inline-block;
+  padding: 0.25rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  background: #e0e0e0;
+}
+
+.controls-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.schedule-session {
+  border: 1px solid #c5d6e2;
+  border-radius: 12px;
+  padding: 0.75rem;
+  margin-bottom: 0.75rem;
+  background: #f8fbff;
+}
+
+.schedule-session header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.5rem;
+}
+
+.schedule-session form {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.material-list {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.material-row {
+  display: grid;
+  grid-template-columns: 1fr 80px auto;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.map-container {
+  position: relative;
+  height: 420px;
+  background: #eef5fb;
+  border-radius: 12px;
+  border: 1px solid #c5d6e2;
+  overflow: hidden;
+}
+
+.map-svg {
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(135deg, rgba(20,61,89,0.08), rgba(255,255,255,0.8));
+}
+
+.map-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.notice {
+  background: #fff0c2;
+  border: 1px solid #f4c542;
+  border-radius: 8px;
+  padding: 0.75rem;
+  color: #5f4a00;
+}
+
+input,
+select,
+textarea {
+  font: inherit;
+  padding: 0.5rem;
+  border: 1px solid #ccd6dd;
+  border-radius: 8px;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+label {
+  display: grid;
+  gap: 0.25rem;
+  font-weight: 600;
+}
+
+fieldset {
+  border: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+legend {
+  font-weight: 700;
+}
+
+.stepper {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin-bottom: 1rem;
+}
+
+.stepper button {
+  border: none;
+  border-radius: 8px;
+  padding: 0.5rem 0.75rem;
+  background: #d6e4f0;
+}
+
+.stepper button.active {
+  background: #143d59;
+  color: #fff;
+}
+
+button.primary {
+  background: #1b76d2;
+  border: none;
+  color: #fff;
+  border-radius: 8px;
+  padding: 0.5rem 1rem;
+}
+
+button.danger {
+  background: #d23f3f;
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  padding: 0.5rem 1rem;
+}
+
+button.ghost {
+  background: transparent;
+  border: 1px solid #143d59;
+  color: #143d59;
+  border-radius: 8px;
+  padding: 0.5rem 1rem;
+}
+
+.badge.success {
+  background: #d9f7be;
+  color: #27632a;
+}
+
+.badge.warning {
+  background: #fff4e5;
+  color: #8a6d3b;
+}
+
+.gantt-container {
+  overflow-x: auto;
+  border: 1px solid #c5d6e2;
+  border-radius: 12px;
+  background: #fff;
+}
+
+.gantt-grid {
+  position: relative;
+  min-width: 720px;
+  padding: 1rem;
+}
+
+.gantt-row {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 0.75rem;
+}
+
+.gantt-label {
+  flex: 0 0 140px;
+  font-weight: 600;
+}
+
+.gantt-track {
+  position: relative;
+  flex: 1;
+  height: 48px;
+  background: #eef5fb;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.gantt-block {
+  position: absolute;
+  top: 4px;
+  height: 40px;
+  border-radius: 6px;
+  padding: 0.25rem 0.5rem;
+  color: #fff;
+  font-size: 0.8rem;
+  display: flex;
+  align-items: center;
+}
+
+.gantt-axis {
+  display: flex;
+  gap: 1rem;
+  margin-bottom: 1rem;
+  font-size: 0.85rem;
+}
+
+.home-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.home-card {
+  background: #fff;
+  padding: 1.5rem;
+  border-radius: 12px;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.08);
+}
+
+.home-card button {
+  margin-top: 1rem;
+}
+
+hr {
+  border: none;
+  border-top: 1px solid #dde6ee;
+  margin: 1.5rem 0;
+}

--- a/apps/project-editor/src/App.tsx
+++ b/apps/project-editor/src/App.tsx
@@ -1,0 +1,211 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { FileMenu } from './components/FileMenu';
+import { ProjectForm } from './components/ProjectForm';
+import { ScheduleEditor } from './components/ScheduleEditor';
+import { StaffManager } from './components/StaffManager';
+import { GanttView } from './components/GanttView';
+import { MaterialsView } from './components/MaterialsView';
+import { MapView } from './components/MapView';
+import { Wizard } from './components/Wizard';
+import { useProjectStore } from './state/projectStore';
+import { openFileDialog } from './adapters/file/upload';
+import { downloadFile } from './adapters/file/download';
+import { deserializeProject, serializeProject } from './core/serialization';
+import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts';
+
+const RESULTS_TABS = [
+  { id: 'gantt', label: 'Horarios' },
+  { id: 'materials', label: 'Materiales' },
+  { id: 'map', label: 'Mapa' }
+] as const;
+
+export default function App() {
+  const project = useProjectStore((state) => state.project);
+  const createProject = useProjectStore((state) => state.createProject);
+  const loadProject = useProjectStore((state) => state.loadProject);
+  const hasUnsavedChanges = useProjectStore((state) => state.hasUnsavedChanges);
+  const markSaved = useProjectStore((state) => state.markSaved);
+  const resetProject = useProjectStore((state) => state.resetProject);
+  const lastSavedAt = useProjectStore((state) => state.lastSavedAt);
+  const autosaveLoaded = useProjectStore((state) => state.autosaveLoaded);
+
+  const [currentStep, setCurrentStep] = useState<'home' | 'project' | 'client' | 'staff' | 'results'>('home');
+  const [resultsTab, setResultsTab] = useState<typeof RESULTS_TABS[number]['id']>('gantt');
+  const [zoom, setZoom] = useState(1);
+  const togglePlayRef = useRef<() => void>();
+
+  const goToStep = (step: typeof currentStep) => setCurrentStep(step);
+
+  const confirmDiscard = () => {
+    if (!project || !hasUnsavedChanges) return true;
+    return window.confirm('Hay cambios sin guardar. ¿Deseas continuar y descartar los cambios?');
+  };
+
+  const handleNewProject = () => {
+    if (!confirmDiscard()) return;
+    const nombre = window.prompt('Nombre del proyecto');
+    if (!nombre) return;
+    const defaultDate = new Date().toISOString().slice(0, 10);
+    const inicio = window.prompt('Fecha de inicio (YYYY-MM-DD)', defaultDate) ?? defaultDate;
+    const fin = window.prompt('Fecha de fin (YYYY-MM-DD)', defaultDate) ?? defaultDate;
+    createProject({ nombre, inicio: new Date(`${inicio}T00:00:00`).toISOString(), fin: new Date(`${fin}T23:59:00`).toISOString() });
+    setCurrentStep('project');
+  };
+
+  const handleOpenProject = async () => {
+    if (!confirmDiscard()) return;
+    const contents = await openFileDialog();
+    if (!contents) return;
+    try {
+      const parsed = deserializeProject(contents);
+      loadProject(parsed);
+      setCurrentStep('project');
+    } catch (error) {
+      window.alert('No se pudo cargar el archivo. Asegúrate de que es un .eventplan.json válido.');
+      console.error(error);
+    }
+  };
+
+  const handleSaveAs = () => {
+    if (!project) return;
+    const json = serializeProject(project);
+    downloadFile(`${project.nombre}.eventplan.json`, json);
+    markSaved();
+  };
+
+  const handleReset = () => {
+    if (!confirmDiscard()) return;
+    resetProject();
+    setCurrentStep('home');
+  };
+
+  useEffect(() => {
+    const beforeUnload = (event: BeforeUnloadEvent) => {
+      if (hasUnsavedChanges) {
+        event.preventDefault();
+        event.returnValue = '';
+      }
+    };
+    window.addEventListener('beforeunload', beforeUnload);
+    return () => window.removeEventListener('beforeunload', beforeUnload);
+  }, [hasUnsavedChanges]);
+
+  useKeyboardShortcuts({
+    onSave: handleSaveAs,
+    onOpen: handleOpenProject,
+    onNew: handleNewProject,
+    onTogglePlay: () => togglePlayRef.current?.(),
+    onZoomIn: () => setZoom((prev) => Math.min(4, prev + 0.25)),
+    onZoomOut: () => setZoom((prev) => Math.max(0.5, prev - 0.25))
+  });
+
+  const steps = useMemo(() => {
+    return [
+      {
+        id: 'project',
+        label: 'Proyecto',
+        content: <ProjectForm />,
+        disabled: !project
+      },
+      {
+        id: 'client',
+        label: 'Cliente',
+        content: project && project.cliente ? (
+          <ScheduleEditor ownerId={project.cliente.id} ownerRol="CLIENTE" ownerNombre={project.cliente.nombre} />
+        ) : (
+          <p className="notice">Configura la información del cliente primero.</p>
+        ),
+        disabled: !project
+      },
+      {
+        id: 'staff',
+        label: 'Staff',
+        content: <StaffManager />,
+        disabled: !project
+      },
+      {
+        id: 'results',
+        label: 'Resultados',
+        content: (
+          <section className="grid">
+            <nav className="tab-bar" role="tablist">
+              {RESULTS_TABS.map((tab) => (
+                <button
+                  key={tab.id}
+                  type="button"
+                  role="tab"
+                  className={`tab-button ${resultsTab === tab.id ? 'active' : ''}`}
+                  aria-selected={resultsTab === tab.id}
+                  onClick={() => setResultsTab(tab.id)}
+                >
+                  {tab.label}
+                </button>
+              ))}
+            </nav>
+            {resultsTab === 'gantt' && <GanttView zoom={zoom} onZoomChange={setZoom} />}
+            {resultsTab === 'materials' && <MaterialsView />}
+            {resultsTab === 'map' && <MapView registerTogglePlay={(toggle) => (togglePlayRef.current = toggle)} />}
+          </section>
+        ),
+        disabled: !project
+      }
+    ];
+  }, [project, resultsTab, zoom]);
+
+  const showHome = currentStep === 'home' || !project;
+
+  return (
+    <div className="app-shell">
+      <header className="app-header">
+        <h1>Editor de proyectos</h1>
+        <FileMenu
+          onNew={handleNewProject}
+          onOpen={handleOpenProject}
+          onSaveAs={handleSaveAs}
+          hasProject={Boolean(project)}
+          hasUnsavedChanges={hasUnsavedChanges}
+          lastSavedAt={lastSavedAt}
+        />
+        {project && (
+          <button type="button" className="ghost" onClick={handleReset}>
+            Volver al inicio
+          </button>
+        )}
+      </header>
+      <main className="app-main">
+        {autosaveLoaded && project && (
+          <p className="notice">Se restauró un borrador guardado automáticamente.</p>
+        )}
+        {showHome ? (
+          <section className="grid">
+            <div className="home-grid">
+              <article className="home-card">
+                <h2>Nuevo proyecto</h2>
+                <p>Configura un nuevo evento desde cero.</p>
+                <button type="button" className="primary" onClick={handleNewProject}>
+                  Nuevo
+                </button>
+              </article>
+              <article className="home-card">
+                <h2>Abrir proyecto</h2>
+                <p>Importa un archivo .eventplan.json existente.</p>
+                <button type="button" className="ghost" onClick={handleOpenProject}>
+                  Abrir…
+                </button>
+              </article>
+              <article className="home-card">
+                <h2>Continuar</h2>
+                <p>Accede al asistente para seguir editando el proyecto actual.</p>
+                <button type="button" className="ghost" onClick={() => goToStep('project')} disabled={!project}>
+                  Ir al asistente
+                </button>
+              </article>
+            </div>
+          </section>
+        ) : (
+          <Wizard steps={steps} currentStep={currentStep === 'home' ? 'project' : currentStep} onStepChange={(id) => setCurrentStep(id as typeof currentStep)} />
+        )}
+      </main>
+    </div>
+  );
+}

--- a/apps/project-editor/src/adapters/datetime/index.ts
+++ b/apps/project-editor/src/adapters/datetime/index.ts
@@ -1,0 +1,11 @@
+import { addMinutes, differenceInMinutes, formatISO, isAfter, isBefore, parseISO } from 'date-fns';
+
+export const parseDate = (iso: string) => parseISO(iso);
+export const toISO = (date: Date) => formatISO(date);
+export const addMinutesToISO = (iso: string, minutes: number) => formatISO(addMinutes(parseISO(iso), minutes));
+export const minutesBetween = (startISO: string, endISO: string) => differenceInMinutes(parseISO(endISO), parseISO(startISO));
+export const isBeforeISO = (a: string, b: string) => isBefore(parseISO(a), parseISO(b));
+export const isAfterISO = (a: string, b: string) => isAfter(parseISO(a), parseISO(b));
+export const nowISO = () => formatISO(new Date());
+export const toDisplayTime = (iso: string) => new Date(iso).toLocaleTimeString('es-ES', { hour: '2-digit', minute: '2-digit' });
+export const toDisplayDate = (iso: string) => new Date(iso).toLocaleDateString('es-ES');

--- a/apps/project-editor/src/adapters/file/download.ts
+++ b/apps/project-editor/src/adapters/file/download.ts
@@ -1,0 +1,11 @@
+export const downloadFile = (filename: string, contents: string) => {
+  const blob = new Blob([contents], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = filename;
+  document.body.append(anchor);
+  anchor.click();
+  anchor.remove();
+  URL.revokeObjectURL(url);
+};

--- a/apps/project-editor/src/adapters/file/upload.ts
+++ b/apps/project-editor/src/adapters/file/upload.ts
@@ -1,0 +1,17 @@
+export const openFileDialog = async (): Promise<string | null> => {
+  return new Promise((resolve) => {
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.accept = '.eventplan.json,application/json';
+    input.addEventListener('change', async () => {
+      const file = input.files?.[0];
+      if (!file) {
+        resolve(null);
+        return;
+      }
+      const text = await file.text();
+      resolve(text);
+    });
+    input.click();
+  });
+};

--- a/apps/project-editor/src/adapters/state/store.ts
+++ b/apps/project-editor/src/adapters/state/store.ts
@@ -1,0 +1,6 @@
+import { createStore as createZustandStore, type StateCreator } from 'zustand';
+
+export type { StateCreator } from 'zustand';
+export type StoreApi<T> = ReturnType<typeof createZustandStore<T>>;
+
+export const createStore = <T>(creator: StateCreator<T>) => createZustandStore(creator);

--- a/apps/project-editor/src/adapters/storage/local.ts
+++ b/apps/project-editor/src/adapters/storage/local.ts
@@ -1,0 +1,24 @@
+const STORAGE_KEY = 'project-editor:autosave';
+
+export const readAutosave = (): string | null => {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+  return window.localStorage.getItem(STORAGE_KEY);
+};
+
+export const writeAutosave = (value: string) => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  window.localStorage.setItem(STORAGE_KEY, value);
+};
+
+export const clearAutosave = () => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  window.localStorage.removeItem(STORAGE_KEY);
+};
+
+export const storageKey = STORAGE_KEY;

--- a/apps/project-editor/src/adapters/uuid/index.ts
+++ b/apps/project-editor/src/adapters/uuid/index.ts
@@ -1,0 +1,6 @@
+export const createId = () => {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+    return crypto.randomUUID();
+  }
+  return `id-${Math.random().toString(36).slice(2, 10)}`;
+};

--- a/apps/project-editor/src/components/FileMenu.tsx
+++ b/apps/project-editor/src/components/FileMenu.tsx
@@ -1,0 +1,37 @@
+import type { FC } from 'react';
+
+interface Props {
+  onNew: () => void;
+  onOpen: () => void;
+  onSaveAs: () => void;
+  hasProject: boolean;
+  hasUnsavedChanges: boolean;
+  lastSavedAt?: string | null;
+}
+
+export const FileMenu: FC<Props> = ({ onNew, onOpen, onSaveAs, hasProject, hasUnsavedChanges, lastSavedAt }) => {
+  return (
+    <div className="controls-row" role="menubar" aria-label="Menú de archivo">
+      <button type="button" onClick={onNew} className="primary">
+        Nuevo
+      </button>
+      <button type="button" onClick={onOpen} className="ghost">
+        Abrir…
+      </button>
+      <button type="button" onClick={onSaveAs} className="ghost" disabled={!hasProject} aria-disabled={!hasProject}>
+        Guardar como…
+      </button>
+      {hasProject && (
+        <span aria-live="polite">
+          {hasUnsavedChanges ? (
+            <span className="badge warning">Cambios sin guardar</span>
+          ) : (
+            <span className="badge success">
+              Guardado {lastSavedAt ? new Date(lastSavedAt).toLocaleTimeString('es-ES') : 'recientemente'}
+            </span>
+          )}
+        </span>
+      )}
+    </div>
+  );
+};

--- a/apps/project-editor/src/components/GanttView.tsx
+++ b/apps/project-editor/src/components/GanttView.tsx
@@ -1,0 +1,161 @@
+import type { FC } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import { useProjectStore } from '../state/projectStore';
+import type { Session } from '../domain/types';
+
+const colorPalette = ['#1b76d2', '#d23f3f', '#17a398', '#f29f05', '#6a3fb1', '#2a6f4c'];
+
+interface Props {
+  zoom: number;
+  onZoomChange: (value: number) => void;
+}
+
+export const GanttView: FC<Props> = ({ zoom, onZoomChange }) => {
+  const project = useProjectStore((state) => state.project);
+
+  const owners = useMemo(() => {
+    if (!project) return [] as Array<{ id: string; nombre: string; rol: Session['ownerRol'] }>;
+    const list: Array<{ id: string; nombre: string; rol: Session['ownerRol'] }> = [];
+    if (project.cliente) {
+      list.push({ id: project.cliente.id, nombre: `Cliente: ${project.cliente.nombre}`, rol: 'CLIENTE' });
+    }
+    project.staff.forEach((member) => list.push({ id: member.id, nombre: `Staff: ${member.nombre}`, rol: 'STAFF' }));
+    return list;
+  }, [project]);
+
+  const [activeOwners, setActiveOwners] = useState<Set<string>>(() => new Set(owners.map((owner) => owner.id)));
+
+  useEffect(() => {
+    setActiveOwners((prev) => {
+      const ownerIds = owners.map((owner) => owner.id);
+      const next = new Set(prev);
+      let changed = false;
+
+      ownerIds.forEach((id) => {
+        if (!next.has(id)) {
+          next.add(id);
+          changed = true;
+        }
+      });
+
+      Array.from(next).forEach((id) => {
+        if (!ownerIds.includes(id)) {
+          next.delete(id);
+          changed = true;
+        }
+      });
+
+      return changed ? next : prev;
+    });
+  }, [owners]);
+
+  if (!project) {
+    return <p className="notice">Crea un proyecto para visualizar los horarios.</p>;
+  }
+
+  const filteredSessions = project.sesiones.filter((session) => activeOwners.has(session.ownerId));
+
+  if (filteredSessions.length === 0) {
+    return (
+      <div className="card">
+        <h3>Horarios</h3>
+        <p>No hay sesiones para mostrar. Añade segmentos al cliente o al staff.</p>
+      </div>
+    );
+  }
+
+  const sortedSessions = [...filteredSessions].sort((a, b) => (a.inicioISO < b.inicioISO ? -1 : 1));
+  const minStart = new Date(sortedSessions[0].inicioISO).getTime();
+  const maxEnd = new Date(sortedSessions[sortedSessions.length - 1].finISO).getTime();
+  const totalMinutes = Math.max(1, Math.round((maxEnd - minStart) / 60000));
+  const pixelsPerMinute = 2 * zoom;
+
+  const axisLabels = (() => {
+    const labels: string[] = [];
+    const axisStart = new Date(minStart);
+    axisStart.setMinutes(0, 0, 0);
+    for (let time = axisStart.getTime(); time <= maxEnd; time += 60 * 60 * 1000) {
+      labels.push(new Date(time).toLocaleString('es-ES', { hour: '2-digit', minute: '2-digit', day: '2-digit', month: '2-digit' }));
+    }
+    return labels;
+  })();
+
+  const computeLeft = (session: Session) => ((new Date(session.inicioISO).getTime() - minStart) / 60000) * pixelsPerMinute;
+  const computeWidth = (session: Session) => (new Date(session.finISO).getTime() - new Date(session.inicioISO).getTime()) / 60000 * pixelsPerMinute;
+
+  return (
+    <section className="card">
+      <header className="controls-row">
+        <h3>Horarios</h3>
+        <div className="controls-row" role="group" aria-label="Zoom">
+          <button type="button" onClick={() => onZoomChange(Math.max(0.5, zoom - 0.25))} className="ghost">
+            -
+          </button>
+          <span>Zoom {zoom.toFixed(2)}x</span>
+          <button type="button" onClick={() => onZoomChange(Math.min(4, zoom + 0.25))} className="ghost">
+            +
+          </button>
+        </div>
+      </header>
+      <div className="controls-row" role="group" aria-label="Filtros">
+        {owners.map((owner, index) => (
+          <label key={owner.id} style={{ display: 'flex', alignItems: 'center', gap: '0.25rem' }}>
+            <input
+              type="checkbox"
+              checked={activeOwners.has(owner.id)}
+              onChange={(event) => {
+                setActiveOwners((prev) => {
+                  const next = new Set(prev);
+                  if (event.target.checked) {
+                    next.add(owner.id);
+                  } else {
+                    next.delete(owner.id);
+                  }
+                  return next;
+                });
+              }}
+            />
+            <span className="badge" style={{ background: colorPalette[index % colorPalette.length], color: '#fff' }}>
+              {owner.nombre}
+            </span>
+          </label>
+        ))}
+      </div>
+      <div className="gantt-container" role="figure" aria-label="Vista tipo Gantt">
+        <div className="gantt-axis">
+          {axisLabels.map((label) => (
+            <span key={label}>{label}</span>
+          ))}
+        </div>
+        <div className="gantt-grid" style={{ width: totalMinutes * pixelsPerMinute + 200 }}>
+          {owners
+            .filter((owner) => activeOwners.has(owner.id))
+            .map((owner, ownerIndex) => {
+              const sessions = project.sesiones.filter((session) => session.ownerId === owner.id);
+              return (
+                <div className="gantt-row" key={owner.id}>
+                  <div className="gantt-label">{owner.nombre}</div>
+                  <div className="gantt-track">
+                    {sessions.map((session) => (
+                      <div
+                        key={session.id}
+                        className="gantt-block"
+                        style={{
+                          left: computeLeft(session),
+                          width: Math.max(24, computeWidth(session)),
+                          background: colorPalette[ownerIndex % colorPalette.length]
+                        }}
+                        title={`${new Date(session.inicioISO).toLocaleTimeString('es-ES', { hour: '2-digit', minute: '2-digit' })} - ${new Date(session.finISO).toLocaleTimeString('es-ES', { hour: '2-digit', minute: '2-digit' })}`}
+                      >
+                        {session.tareaId ? project.tareas.find((t) => t.id === session.tareaId)?.nombre ?? 'Sesión' : 'Sesión'}
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              );
+            })}
+        </div>
+      </div>
+    </section>
+  );
+};

--- a/apps/project-editor/src/components/MapView.tsx
+++ b/apps/project-editor/src/components/MapView.tsx
@@ -1,0 +1,165 @@
+import type { FC } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import { useProjectStore } from '../state/projectStore';
+import { buildLocationLayout, getOwnerPositionAt, getTimelineBounds } from '../core/simulation';
+import type { Session } from '../domain/types';
+
+const speeds = [0.5, 1, 2, 4];
+
+interface Props {
+  registerTogglePlay?: (toggle: () => void) => void;
+}
+
+export const MapView: FC<Props> = ({ registerTogglePlay }) => {
+  const project = useProjectStore((state) => state.project);
+  const [currentTime, setCurrentTime] = useState<string | null>(null);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [speed, setSpeed] = useState(1);
+
+  const timelineBounds = useMemo(() => (project ? getTimelineBounds(project) : null), [project]);
+  const layout = useMemo(() => (project ? buildLocationLayout(project) : new Map()), [project]);
+
+  useEffect(() => {
+    if (timelineBounds && !currentTime) {
+      setCurrentTime(timelineBounds.inicio);
+    }
+  }, [timelineBounds, currentTime]);
+
+  useEffect(() => {
+    registerTogglePlay?.(() => setIsPlaying((prev) => !prev));
+  }, [registerTogglePlay]);
+
+  useEffect(() => {
+    if (!isPlaying || !currentTime || !timelineBounds) return;
+    const interval = window.setInterval(() => {
+      setCurrentTime((prev) => {
+        if (!prev) return prev;
+        const date = new Date(prev);
+        date.setMinutes(date.getMinutes() + speed);
+        if (date.toISOString() > timelineBounds.fin) {
+          setIsPlaying(false);
+          return timelineBounds.fin;
+        }
+        return date.toISOString();
+      });
+    }, 1000);
+    return () => window.clearInterval(interval);
+  }, [isPlaying, speed, timelineBounds, currentTime]);
+
+  if (!project) {
+    return <p className="notice">Crea un proyecto para activar la simulación en el mapa.</p>;
+  }
+
+  const owners: Array<{ id: string; nombre: string; rol: Session['ownerRol'] }> = [];
+  if (project.cliente) {
+    owners.push({ id: project.cliente.id, nombre: `Cliente: ${project.cliente.nombre}`, rol: 'CLIENTE' });
+  }
+  project.staff.forEach((member) => owners.push({ id: member.id, nombre: `Staff: ${member.nombre}`, rol: 'STAFF' }));
+
+  const ownerPositions = owners.map((owner) => {
+    const sessions = project.sesiones.filter((session) => session.ownerId === owner.id);
+    const position = currentTime ? getOwnerPositionAt(sessions, layout, currentTime) : null;
+    return { owner, position };
+  });
+
+  const goToMinutes = (minutes: number) => {
+    if (!currentTime) return;
+    const date = new Date(currentTime);
+    date.setMinutes(date.getMinutes() + minutes);
+    if (timelineBounds) {
+      if (date.toISOString() < timelineBounds.inicio) {
+        setCurrentTime(timelineBounds.inicio);
+        return;
+      }
+      if (date.toISOString() > timelineBounds.fin) {
+        setCurrentTime(timelineBounds.fin);
+        return;
+      }
+    }
+    setCurrentTime(date.toISOString());
+  };
+
+  const handleGoToHour = (value: string) => {
+    if (!timelineBounds) return;
+    const baseDate = new Date(timelineBounds.inicio);
+    const [hours, minutes] = value.split(':');
+    baseDate.setHours(Number(hours), Number(minutes), 0, 0);
+    const iso = baseDate.toISOString();
+    if (timelineBounds && (iso < timelineBounds.inicio || iso > timelineBounds.fin)) {
+      setCurrentTime(timelineBounds.inicio);
+    } else {
+      setCurrentTime(iso);
+    }
+  };
+
+  if (!timelineBounds) {
+    return (
+      <section className="card">
+        <h3>Mapa y simulación</h3>
+        <p>No hay sesiones planificadas todavía. Añade segmentos para visualizar el movimiento.</p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="card">
+      <header className="controls-row">
+        <h3>Mapa y simulación</h3>
+        <div className="controls-row">
+          <button type="button" className="primary" onClick={() => setIsPlaying((prev) => !prev)} disabled={!timelineBounds}>
+            {isPlaying ? 'Pausa' : 'Play'}
+          </button>
+          <span>{currentTime ? new Date(currentTime).toLocaleString('es-ES') : 'Sin hora seleccionada'}</span>
+          <label>
+            Velocidad
+            <select value={speed} onChange={(event) => setSpeed(Number(event.target.value))}>
+              {speeds.map((value) => (
+                <option key={value} value={value}>
+                  {value}×
+                </option>
+              ))}
+            </select>
+          </label>
+          <button type="button" className="ghost" onClick={() => goToMinutes(-15)}>
+            −15 min
+          </button>
+          <button type="button" className="ghost" onClick={() => goToMinutes(-5)}>
+            −5 min
+          </button>
+          <button type="button" className="ghost" onClick={() => goToMinutes(5)}>
+            +5 min
+          </button>
+          <button type="button" className="ghost" onClick={() => goToMinutes(15)}>
+            +15 min
+          </button>
+          <label>
+            Ir a hora
+            <input type="time" onChange={(event) => handleGoToHour(event.target.value)} />
+          </label>
+        </div>
+      </header>
+      <div className="map-container" role="application" aria-label="Mapa de ubicaciones">
+        <svg className="map-svg" viewBox="0 0 100 66" aria-hidden="true">
+          {Array.from(layout.entries()).map(([id, point]) => (
+            <g key={id}>
+              <circle cx={point.x * 100} cy={point.y * 66} r={2.5} fill="#143d59" />
+              <text x={point.x * 100 + 3} y={point.y * 66} fontSize={2.5} fill="#143d59">
+                {project.ubicaciones.find((loc) => loc.id === id)?.nombre ?? 'Ubicación'}
+              </text>
+            </g>
+          ))}
+          {ownerPositions.map(({ owner, position }, index) => (
+            position && (
+              <g key={owner.id}>
+                <circle cx={position.x * 100} cy={position.y * 66} r={3.5} fill={index === 0 ? '#d23f3f' : '#1b76d2'} opacity={0.8} />
+                <text x={position.x * 100 + 3} y={position.y * 66 - 2} fontSize={2.5} fill="#000">
+                  {owner.nombre}
+                </text>
+              </g>
+            )
+          ))}
+        </svg>
+      </div>
+    </section>
+  );
+};

--- a/apps/project-editor/src/components/MaterialsView.tsx
+++ b/apps/project-editor/src/components/MaterialsView.tsx
@@ -1,0 +1,70 @@
+import type { FC } from 'react';
+import { useMemo } from 'react';
+import { useProjectStore } from '../state/projectStore';
+import { aggregateMaterials, materialsToCSV } from '../core/materials';
+import { downloadFile } from '../adapters/file/download';
+
+export const MaterialsView: FC = () => {
+  const project = useProjectStore((state) => state.project);
+
+  const aggregation = useMemo(() => (project ? aggregateMaterials(project) : { resumen: [] }), [project]);
+
+  if (!project) {
+    return <p className="notice">Crea un proyecto para ver el resumen de materiales.</p>;
+  }
+
+  return (
+    <section className="card">
+      <header className="controls-row">
+        <h3>Materiales agregados</h3>
+        <button
+          type="button"
+          className="ghost"
+          onClick={() => downloadFile(`${project.nombre}.materiales.csv`, materialsToCSV(aggregation))}
+          disabled={aggregation.resumen.length === 0}
+        >
+          Exportar CSV
+        </button>
+      </header>
+      {aggregation.resumen.length === 0 ? (
+        <p>No hay materiales asignados en las sesiones.</p>
+      ) : (
+        <table className="table">
+          <thead>
+            <tr>
+              <th>Material</th>
+              <th>Unidad</th>
+              <th>Total</th>
+              <th>Persona</th>
+              <th>Rol</th>
+              <th>Cantidad</th>
+            </tr>
+          </thead>
+          <tbody>
+            {aggregation.resumen.flatMap((row) => (
+              row.porPersona.length > 0
+                ? row.porPersona.map((persona, index) => (
+                    <tr key={`${row.materialId}-${persona.ownerId}-${index}`}>
+                      <td>{index === 0 ? row.nombre : ''}</td>
+                      <td>{index === 0 ? row.unidad : ''}</td>
+                      <td>{index === 0 ? row.cantidadTotal : ''}</td>
+                      <td>{persona.ownerNombre}</td>
+                      <td>{persona.ownerRol}</td>
+                      <td>{persona.cantidad}</td>
+                    </tr>
+                  ))
+                : (
+                    <tr key={`${row.materialId}-total`}>
+                      <td>{row.nombre}</td>
+                      <td>{row.unidad}</td>
+                      <td>{row.cantidadTotal}</td>
+                      <td colSpan={3}>Sin asignar a personas específicas</td>
+                    </tr>
+                  )
+            ))}
+          </tbody>
+        </table>
+      )}
+    </section>
+  );
+};

--- a/apps/project-editor/src/components/ProjectForm.tsx
+++ b/apps/project-editor/src/components/ProjectForm.tsx
@@ -1,0 +1,99 @@
+import type { FC, FormEvent } from 'react';
+import { useEffect, useState } from 'react';
+import { toDateInputValue } from '../utils/time';
+import { useProjectStore } from '../state/projectStore';
+
+export const ProjectForm: FC = () => {
+  const project = useProjectStore((state) => state.project);
+  const updateProjectDetails = useProjectStore((state) => state.updateProjectDetails);
+  const updateCliente = useProjectStore((state) => state.updateCliente);
+  const [localName, setLocalName] = useState(project?.nombre ?? '');
+  const [localNotas, setLocalNotas] = useState(project?.notas ?? '');
+  const [inicio, setInicio] = useState(project ? toDateInputValue(project.fechas.inicio) : '');
+  const [fin, setFin] = useState(project ? toDateInputValue(project.fechas.fin) : '');
+  const [clienteNombre, setClienteNombre] = useState(project?.cliente?.nombre ?? '');
+  const [clienteEmail, setClienteEmail] = useState(project?.cliente?.email ?? '');
+  const [clienteTelefono, setClienteTelefono] = useState(project?.cliente?.telefono ?? '');
+
+  useEffect(() => {
+    if (!project) {
+      setLocalName('');
+      setLocalNotas('');
+      setInicio('');
+      setFin('');
+      setClienteNombre('');
+      setClienteEmail('');
+      setClienteTelefono('');
+      return;
+    }
+    setLocalName(project.nombre);
+    setLocalNotas(project.notas ?? '');
+    setInicio(toDateInputValue(project.fechas.inicio));
+    setFin(toDateInputValue(project.fechas.fin));
+    setClienteNombre(project.cliente?.nombre ?? '');
+    setClienteEmail(project.cliente?.email ?? '');
+    setClienteTelefono(project.cliente?.telefono ?? '');
+  }, [project]);
+
+  if (!project) {
+    return <p className="notice">Crea o abre un proyecto para comenzar.</p>;
+  }
+
+  const onSubmit = (event: FormEvent) => {
+    event.preventDefault();
+    updateProjectDetails({
+      nombre: localName,
+      notas: localNotas,
+      fechas: {
+        inicio: new Date(`${inicio}T00:00:00`).toISOString(),
+        fin: new Date(`${fin}T23:59:00`).toISOString()
+      }
+    });
+    updateCliente({ nombre: clienteNombre, email: clienteEmail, telefono: clienteTelefono });
+  };
+
+  return (
+    <form className="card grid" onSubmit={onSubmit} aria-label="Formulario del proyecto">
+      <h2>Información general</h2>
+      <label>
+        Nombre del proyecto
+        <input value={localName} onChange={(event) => setLocalName(event.target.value)} required />
+      </label>
+      <label>
+        Notas
+        <textarea value={localNotas} onChange={(event) => setLocalNotas(event.target.value)} rows={4} />
+      </label>
+      <div className="grid two">
+        <label>
+          Fecha de inicio
+          <input type="date" value={inicio} onChange={(event) => setInicio(event.target.value)} required />
+        </label>
+        <label>
+          Fecha de fin
+          <input type="date" value={fin} onChange={(event) => setFin(event.target.value)} required />
+        </label>
+      </div>
+      <hr />
+      <h2>Cliente</h2>
+      <div className="grid two">
+        <label>
+          Nombre
+          <input value={clienteNombre} onChange={(event) => setClienteNombre(event.target.value)} required />
+        </label>
+        <label>
+          Email
+          <input type="email" value={clienteEmail} onChange={(event) => setClienteEmail(event.target.value)} placeholder="cliente@correo.com" />
+        </label>
+      </div>
+      <label>
+        Teléfono
+        <input value={clienteTelefono} onChange={(event) => setClienteTelefono(event.target.value)} placeholder="+34 600 000 000" />
+      </label>
+      <div className="controls-row">
+        <button type="submit" className="primary">
+          Guardar cambios
+        </button>
+      </div>
+    </form>
+  );
+};

--- a/apps/project-editor/src/components/ScheduleEditor.tsx
+++ b/apps/project-editor/src/components/ScheduleEditor.tsx
@@ -28,16 +28,20 @@ export const ScheduleEditor: FC<Props> = ({ ownerId, ownerRol, ownerNombre }) =>
     [project?.sesiones, ownerId, ownerRol]
   );
 
-  const [fechaBase, setFechaBase] = useState(() => project ? project.fechas.inicio.slice(0, 10) : '');
-  const [horaBase, setHoraBase] = useState('09:00');
-  const [nextStart, setNextStart] = useState(() => (fechaBase ? fromDateTimeInputs(fechaBase, horaBase) : ''));
+  const defaultFecha = project ? project.fechas.inicio.slice(0, 10) : '';
+  const defaultHora = '09:00';
+  const [fechaBase, setFechaBase] = useState(defaultFecha);
+  const [horaBase, setHoraBase] = useState(defaultHora);
+  const [nextStart, setNextStart] = useState(() => (defaultFecha ? fromDateTimeInputs(defaultFecha, defaultHora) : ''));
 
   if (!project) {
     return <p className="notice">Necesitas crear un proyecto para editar horarios.</p>;
   }
 
   const handleDurationClick = (minutes: number) => {
-    if (!fechaBase) return;
+    if (!fechaBase || !horaBase) {
+      return;
+    }
     const startISO = nextStart || fromDateTimeInputs(fechaBase, horaBase);
     const sessions = appendSequentialSessions({ startISO, durations: [minutes], ownerId, ownerRol });
     if (sessions.length > 0) {
@@ -118,10 +122,15 @@ export const ScheduleEditor: FC<Props> = ({ ownerId, ownerRol, ownerNombre }) =>
         <div className="controls-row" role="group" aria-label="Configuración de inicio">
           <label>
             Fecha base
-            <input type="date" value={fechaBase} onChange={(event) => {
-              setFechaBase(event.target.value);
-              setNextStart(fromDateTimeInputs(event.target.value, horaBase));
-            }} />
+            <input
+              type="date"
+              value={fechaBase}
+              onChange={(event) => {
+                const value = event.target.value;
+                setFechaBase(value);
+                setNextStart(value && horaBase ? fromDateTimeInputs(value, horaBase) : '');
+              }}
+            />
           </label>
           <label>
             Hora inicial
@@ -129,8 +138,9 @@ export const ScheduleEditor: FC<Props> = ({ ownerId, ownerRol, ownerNombre }) =>
               type="time"
               value={horaBase}
               onChange={(event) => {
-                setHoraBase(event.target.value);
-                setNextStart(fromDateTimeInputs(fechaBase, event.target.value));
+                const value = event.target.value;
+                setHoraBase(value);
+                setNextStart(fechaBase && value ? fromDateTimeInputs(fechaBase, value) : '');
               }}
             />
           </label>

--- a/apps/project-editor/src/components/ScheduleEditor.tsx
+++ b/apps/project-editor/src/components/ScheduleEditor.tsx
@@ -1,0 +1,255 @@
+import type { FC, ChangeEvent } from 'react';
+import { useState, useMemo } from 'react';
+import { minutesOptions, fromDateTimeInputs, toTimeInputValue } from '../utils/time';
+import { useProjectStore } from '../state/projectStore';
+import type { Session } from '../domain/types';
+
+interface Props {
+  ownerId: string;
+  ownerRol: Session['ownerRol'];
+  ownerNombre: string;
+}
+
+export const ScheduleEditor: FC<Props> = ({ ownerId, ownerRol, ownerNombre }) => {
+  const project = useProjectStore((state) => state.project);
+  const appendSequentialSessions = useProjectStore((state) => state.appendSequentialSessions);
+  const updateSession = useProjectStore((state) => state.updateSession);
+  const removeSession = useProjectStore((state) => state.removeSession);
+  const changeDuration = useProjectStore((state) => state.changeSessionDuration);
+  const shiftSession = useProjectStore((state) => state.shiftSession);
+  const addLocation = useProjectStore((state) => state.addLocation);
+  const addTaskType = useProjectStore((state) => state.addTaskType);
+  const addMaterialType = useProjectStore((state) => state.addMaterialType);
+  const setSessionMaterials = useProjectStore((state) => state.setSessionMaterials);
+  const lastError = useProjectStore((state) => state.lastError);
+
+  const ownerSessions = useMemo(
+    () => project?.sesiones.filter((session) => session.ownerId === ownerId && session.ownerRol === ownerRol) ?? [],
+    [project?.sesiones, ownerId, ownerRol]
+  );
+
+  const [fechaBase, setFechaBase] = useState(() => project ? project.fechas.inicio.slice(0, 10) : '');
+  const [horaBase, setHoraBase] = useState('09:00');
+  const [nextStart, setNextStart] = useState(() => (fechaBase ? fromDateTimeInputs(fechaBase, horaBase) : ''));
+
+  if (!project) {
+    return <p className="notice">Necesitas crear un proyecto para editar horarios.</p>;
+  }
+
+  const handleDurationClick = (minutes: number) => {
+    if (!fechaBase) return;
+    const startISO = nextStart || fromDateTimeInputs(fechaBase, horaBase);
+    const sessions = appendSequentialSessions({ startISO, durations: [minutes], ownerId, ownerRol });
+    if (sessions.length > 0) {
+      setNextStart(sessions[sessions.length - 1].finISO);
+    }
+  };
+
+  const handleSessionChange = (session: Session, field: 'locationId' | 'tareaId', value: string | undefined) => {
+    if (field === 'locationId') {
+      updateSession(session.id, { locationId: value });
+    } else {
+      updateSession(session.id, { tareaId: value });
+    }
+  };
+
+  const handleInfoChange = (session: Session, event: ChangeEvent<HTMLTextAreaElement>) => {
+    updateSession(session.id, { infoExtra: event.target.value });
+  };
+
+  const handleMaterialQuantityChange = (session: Session, index: number, quantity: number) => {
+    const materials = session.materiales ? [...session.materiales] : [];
+    materials[index] = { ...materials[index], cantidad: quantity };
+    setSessionMaterials(session.id, materials);
+  };
+
+  const handleMaterialSelectionChange = (session: Session, index: number, materialId: string) => {
+    const materials = session.materiales ? [...session.materiales] : [];
+    materials[index] = { ...materials[index], materialId };
+    setSessionMaterials(session.id, materials);
+  };
+
+  const handleAddMaterial = (session: Session) => {
+    const materials = session.materiales ? [...session.materiales] : [];
+    let materialId: string | undefined = project.materiales[0]?.id;
+
+    if (!materialId) {
+      const nombre = window.prompt('Nombre del material');
+      if (!nombre) return;
+      const unidad = window.prompt('Unidad de medida', 'unidad');
+      if (!unidad) return;
+      const nuevo = addMaterialType({ nombre, unidad });
+      if (!nuevo) return;
+      materialId = nuevo.id;
+    }
+
+    if (!materialId) return;
+
+    materials.push({ materialId, cantidad: 1 });
+    setSessionMaterials(session.id, materials);
+  };
+
+  const handleRemoveMaterial = (session: Session, index: number) => {
+    const materials = session.materiales ? [...session.materiales] : [];
+    materials.splice(index, 1);
+    setSessionMaterials(session.id, materials);
+  };
+
+  const ensureLocation = () => {
+    const nombre = window.prompt('Nombre de la ubicación');
+    if (!nombre) return;
+    const latStr = window.prompt('Latitud (opcional)');
+    const lngStr = window.prompt('Longitud (opcional)');
+    const lat = latStr ? Number(latStr) : undefined;
+    const lng = lngStr ? Number(lngStr) : undefined;
+    addLocation({ nombre, lat, lng });
+  };
+
+  const ensureTask = () => {
+    const nombre = window.prompt('Nombre de la tarea');
+    if (!nombre) return;
+    addTaskType({ nombre });
+  };
+
+  return (
+    <section className="card" aria-label={`Horario de ${ownerNombre}`}>
+      <header className="controls-row">
+        <h2>Horario de {ownerNombre}</h2>
+        <div className="controls-row" role="group" aria-label="Configuración de inicio">
+          <label>
+            Fecha base
+            <input type="date" value={fechaBase} onChange={(event) => {
+              setFechaBase(event.target.value);
+              setNextStart(fromDateTimeInputs(event.target.value, horaBase));
+            }} />
+          </label>
+          <label>
+            Hora inicial
+            <input
+              type="time"
+              value={horaBase}
+              onChange={(event) => {
+                setHoraBase(event.target.value);
+                setNextStart(fromDateTimeInputs(fechaBase, event.target.value));
+              }}
+            />
+          </label>
+        </div>
+        <div className="controls-row" role="group" aria-label="Crear segmento">
+          {minutesOptions.map((minutes) => (
+            <button type="button" key={minutes} onClick={() => handleDurationClick(minutes)} className="ghost">
+              +{minutes} min
+            </button>
+          ))}
+        </div>
+      </header>
+      {lastError && <p className="notice" role="alert">{lastError}</p>}
+      {ownerSessions.length === 0 && <p>No hay segmentos asignados todavía.</p>}
+      {ownerSessions.map((session) => (
+        <article key={session.id} className="schedule-session">
+          <header>
+            <strong>
+              {new Date(session.inicioISO).toLocaleString('es-ES', {
+                hour: '2-digit',
+                minute: '2-digit',
+                day: '2-digit',
+                month: '2-digit'
+              })}{' '}
+              - {toTimeInputValue(session.finISO)}
+            </strong>
+            <div className="controls-row">
+              <button type="button" onClick={() => shiftSession(session.id, -5)} className="ghost" aria-label="Adelantar 5 minutos">
+                -5
+              </button>
+              <button type="button" onClick={() => shiftSession(session.id, 5)} className="ghost" aria-label="Retrasar 5 minutos">
+                +5
+              </button>
+              <button type="button" onClick={() => removeSession(session.id)} className="danger">
+                Eliminar
+              </button>
+            </div>
+          </header>
+          <form className="grid" aria-label="Editar segmento">
+            <label>
+              Ubicación
+              <select
+                value={session.locationId ?? ''}
+                onChange={(event) => handleSessionChange(session, 'locationId', event.target.value || undefined)}
+              >
+                <option value="">Selecciona ubicación</option>
+                {project.ubicaciones.map((loc) => (
+                  <option value={loc.id} key={loc.id}>
+                    {loc.nombre}
+                  </option>
+                ))}
+              </select>
+              <button type="button" className="ghost" onClick={ensureLocation}>
+                Crear ubicación
+              </button>
+            </label>
+            <label>
+              Tarea
+              <select value={session.tareaId ?? ''} onChange={(event) => handleSessionChange(session, 'tareaId', event.target.value || undefined)}>
+                <option value="">Selecciona tarea</option>
+                {project.tareas.map((task) => (
+                  <option value={task.id} key={task.id}>
+                    {task.nombre}
+                  </option>
+                ))}
+              </select>
+              <button type="button" className="ghost" onClick={ensureTask}>
+                Crear tarea
+              </button>
+            </label>
+            <label>
+              Duración (minutos)
+              <input
+                type="number"
+                min={5}
+                step={5}
+                value={Math.max(5, Math.round((new Date(session.finISO).getTime() - new Date(session.inicioISO).getTime()) / 60000))}
+                onChange={(event) => changeDuration(session.id, Number(event.target.value))}
+              />
+            </label>
+            <fieldset>
+              <legend>Materiales</legend>
+              <div className="material-list">
+                {(session.materiales ?? []).map((material, index) => (
+                  <div className="material-row" key={`${session.id}-${index}`}>
+                    <select
+                      value={material.materialId}
+                      onChange={(event) => handleMaterialSelectionChange(session, index, event.target.value)}
+                    >
+                      {project.materiales.map((item) => (
+                        <option key={item.id} value={item.id}>
+                          {item.nombre}
+                        </option>
+                      ))}
+                    </select>
+                    <input
+                      type="number"
+                      min={0}
+                      step={0.1}
+                      value={material.cantidad}
+                      onChange={(event) => handleMaterialQuantityChange(session, index, Number(event.target.value))}
+                    />
+                    <button type="button" className="ghost" onClick={() => handleRemoveMaterial(session, index)}>
+                      Quitar
+                    </button>
+                  </div>
+                ))}
+              </div>
+              <button type="button" className="ghost" onClick={() => handleAddMaterial(session)}>
+                Añadir material
+              </button>
+            </fieldset>
+            <label>
+              Información extra
+              <textarea value={session.infoExtra ?? ''} onChange={(event) => handleInfoChange(session, event)} rows={3} />
+            </label>
+          </form>
+        </article>
+      ))}
+    </section>
+  );
+};

--- a/apps/project-editor/src/components/StaffManager.tsx
+++ b/apps/project-editor/src/components/StaffManager.tsx
@@ -1,0 +1,63 @@
+import type { FC } from 'react';
+import { useState } from 'react';
+import { useProjectStore } from '../state/projectStore';
+import { ScheduleEditor } from './ScheduleEditor';
+
+export const StaffManager: FC = () => {
+  const project = useProjectStore((state) => state.project);
+  const addStaffMember = useProjectStore((state) => state.addStaffMember);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+
+  if (!project) {
+    return <p className="notice">Crea un proyecto antes de añadir staff.</p>;
+  }
+
+  const handleAddMember = () => {
+    const nombre = window.prompt('Nombre del miembro del staff');
+    if (!nombre) return;
+    const email = window.prompt('Correo electrónico (opcional)') ?? undefined;
+    const telefono = window.prompt('Teléfono (opcional)') ?? undefined;
+    const created = addStaffMember({ nombre, email, telefono });
+    if (created) {
+      setExpandedId(created.id);
+    }
+  };
+
+  const staffSessionsCount = (staffId: string) => project.sesiones.filter((session) => session.ownerId === staffId).length;
+
+  return (
+    <section className="grid">
+      <div className="controls-row">
+        <button type="button" className="primary" onClick={handleAddMember}>
+          Añadir miembro
+        </button>
+      </div>
+      {project.staff.length === 0 && <p>No hay miembros de staff añadidos todavía.</p>}
+      {project.staff.map((member) => {
+        const sessionsCount = staffSessionsCount(member.id);
+        return (
+          <details
+            key={member.id}
+            open={expandedId === member.id}
+            onToggle={(event) => {
+              if ((event.target as HTMLDetailsElement).open) {
+                setExpandedId(member.id);
+              } else if (expandedId === member.id) {
+                setExpandedId(null);
+              }
+            }}
+            className="card"
+          >
+            <summary className="controls-row">
+              <span>{member.nombre}</span>
+              <span className={`badge ${sessionsCount > 0 ? 'success' : 'warning'}`}>
+                {sessionsCount > 0 ? 'Horario completo' : 'Horario incompleto'}
+              </span>
+            </summary>
+            <ScheduleEditor ownerId={member.id} ownerRol="STAFF" ownerNombre={member.nombre} />
+          </details>
+        );
+      })}
+    </section>
+  );
+};

--- a/apps/project-editor/src/components/Wizard.tsx
+++ b/apps/project-editor/src/components/Wizard.tsx
@@ -1,0 +1,39 @@
+import type { FC, ReactNode } from 'react';
+
+export interface WizardStep {
+  id: string;
+  label: string;
+  content: ReactNode;
+  disabled?: boolean;
+}
+
+interface Props {
+  steps: WizardStep[];
+  currentStep: string;
+  onStepChange: (id: string) => void;
+}
+
+export const Wizard: FC<Props> = ({ steps, currentStep, onStepChange }) => {
+  const active = steps.find((step) => step.id === currentStep) ?? steps[0];
+  return (
+    <div>
+      <nav className="stepper" aria-label="Progreso del asistente">
+        {steps.map((step) => (
+          <button
+            key={step.id}
+            type="button"
+            onClick={() => !step.disabled && onStepChange(step.id)}
+            className={step.id === active.id ? 'active' : ''}
+            aria-current={step.id === active.id}
+            disabled={step.disabled}
+          >
+            {step.label}
+          </button>
+        ))}
+      </nav>
+      <div role="region" aria-live="polite">
+        {active.content}
+      </div>
+    </div>
+  );
+};

--- a/apps/project-editor/src/components/__tests__/app-flow.test.tsx
+++ b/apps/project-editor/src/components/__tests__/app-flow.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import App from '../../App';
+import { downloadFile } from '../../adapters/file/download';
+
+vi.mock('../../adapters/file/download', () => ({
+  downloadFile: vi.fn()
+}));
+
+describe('flujo completo del asistente', () => {
+  const promptValues = [
+    'Proyecto Test',
+    '2024-05-01',
+    '2024-05-02',
+    'Ubicación Centro',
+    '',
+    '',
+    'Staff Uno',
+    '',
+    ''
+  ];
+  let promptCalls = 0;
+
+  beforeEach(() => {
+    promptCalls = 0;
+    vi.spyOn(window, 'prompt').mockImplementation(() => promptValues[promptCalls++] ?? '');
+    vi.spyOn(window, 'alert').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('permite crear, editar y exportar un proyecto local', async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    await user.click(screen.getByText('Nuevo', { selector: 'button' }));
+
+    expect(await screen.findByText('Información general')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Cliente' }));
+
+    await user.click(screen.getAllByText('+15 min')[0]);
+
+    await user.click(screen.getByRole('button', { name: 'Crear ubicación' }));
+    const option = await screen.findByRole('option', { name: 'Ubicación Centro' });
+    await user.selectOptions(screen.getByLabelText('Ubicación'), option);
+
+    await user.click(screen.getByRole('button', { name: 'Staff' }));
+    await user.click(screen.getByText('Añadir miembro'));
+
+    const schedule = await screen.findByLabelText('Horario de Staff Uno');
+    await user.click(within(schedule).getAllByText('+15 min')[0]);
+
+    await user.click(screen.getByRole('button', { name: 'Resultados' }));
+    expect(screen.getByText('Horarios')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Guardar como…' }));
+    expect(downloadFile).toHaveBeenCalled();
+  });
+});

--- a/apps/project-editor/src/components/__tests__/app-flow.test.tsx
+++ b/apps/project-editor/src/components/__tests__/app-flow.test.tsx
@@ -60,4 +60,27 @@ describe('flujo completo del asistente', () => {
     await user.click(screen.getByRole('button', { name: 'Guardar como…' }));
     expect(downloadFile).toHaveBeenCalled();
   });
+
+  it('permite reajustar la fecha y la hora base sin errores', async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    await user.click(screen.getByText('Nuevo', { selector: 'button' }));
+
+    await user.click(screen.getByRole('button', { name: 'Cliente' }));
+
+    const schedule = await screen.findByLabelText('Horario de Cliente principal');
+    const dateInput = within(schedule).getByLabelText('Fecha base');
+    const timeInput = within(schedule).getByLabelText('Hora inicial');
+
+    await user.clear(dateInput);
+    await user.type(dateInput, '2024-05-03');
+
+    await user.clear(timeInput);
+    await user.type(timeInput, '10:30');
+
+    await user.click(within(schedule).getAllByText('+15 min')[0]);
+
+    expect(await within(schedule).findByText(/10:30/)).toBeInTheDocument();
+  });
 });

--- a/apps/project-editor/src/core/__tests__/materials.test.ts
+++ b/apps/project-editor/src/core/__tests__/materials.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { aggregateMaterials, materialsToCSV } from '../materials';
+import type { Project } from '../../domain/types';
+
+const sampleProject: Project = {
+  id: 'p1',
+  nombre: 'Demo',
+  notas: '',
+  fechas: { inicio: new Date('2024-01-01T00:00:00Z').toISOString(), fin: new Date('2024-01-02T00:00:00Z').toISOString() },
+  ubicaciones: [],
+  cliente: { id: 'c1', nombre: 'Cliente Demo', rol: 'CLIENTE' },
+  staff: [{ id: 's1', nombre: 'Staff 1', rol: 'STAFF' }],
+  tareas: [],
+  materiales: [
+    { id: 'm1', nombre: 'Silla', unidad: 'unidad' },
+    { id: 'm2', nombre: 'Mesa', unidad: 'unidad' }
+  ],
+  sesiones: [
+    {
+      id: 'session-1',
+      ownerId: 'c1',
+      ownerRol: 'CLIENTE',
+      inicioISO: new Date('2024-01-01T09:00:00Z').toISOString(),
+      finISO: new Date('2024-01-01T10:00:00Z').toISOString(),
+      materiales: [
+        { materialId: 'm1', cantidad: 5 }
+      ]
+    },
+    {
+      id: 'session-2',
+      ownerId: 's1',
+      ownerRol: 'STAFF',
+      inicioISO: new Date('2024-01-01T09:00:00Z').toISOString(),
+      finISO: new Date('2024-01-01T11:00:00Z').toISOString(),
+      materiales: [
+        { materialId: 'm1', cantidad: 2 },
+        { materialId: 'm2', cantidad: 1 }
+      ]
+    }
+  ],
+  creadoAt: new Date().toISOString(),
+  actualizadoAt: new Date().toISOString(),
+  schemaVersion: 1
+};
+
+describe('aggregateMaterials', () => {
+  it('sums quantities per material and person', () => {
+    const result = aggregateMaterials(sampleProject);
+    const silla = result.resumen.find((row) => row.materialId === 'm1');
+    expect(silla?.cantidadTotal).toBe(7);
+    expect(silla?.porPersona).toHaveLength(2);
+  });
+
+  it('exports csv format', () => {
+    const csv = materialsToCSV(aggregateMaterials(sampleProject));
+    expect(csv).toContain('Silla');
+    expect(csv).toContain('Cliente Demo');
+  });
+});

--- a/apps/project-editor/src/core/__tests__/schedule.test.ts
+++ b/apps/project-editor/src/core/__tests__/schedule.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { createSequentialSessions, ownerHasOverlap, sessionsOverlap } from '../schedule';
+
+const baseSession = {
+  ownerId: 'owner-1',
+  ownerRol: 'CLIENTE' as const
+};
+
+describe('schedule helpers', () => {
+  it('creates sequential sessions without gaps', () => {
+    const [first, second] = createSequentialSessions({
+      startISO: new Date('2024-01-01T08:00:00Z').toISOString(),
+      durations: [30, 60],
+      ownerId: baseSession.ownerId,
+      ownerRol: baseSession.ownerRol
+    });
+    expect(first.finISO).toBe(second.inicioISO);
+  });
+
+  it('detects overlapping sessions for same owner', () => {
+    const [first] = createSequentialSessions({
+      startISO: new Date('2024-01-01T09:00:00Z').toISOString(),
+      durations: [60],
+      ownerId: baseSession.ownerId,
+      ownerRol: baseSession.ownerRol
+    });
+    const [second] = createSequentialSessions({
+      startISO: new Date('2024-01-01T09:30:00Z').toISOString(),
+      durations: [60],
+      ownerId: baseSession.ownerId,
+      ownerRol: baseSession.ownerRol
+    });
+    expect(sessionsOverlap(first, second)).toBe(true);
+    expect(ownerHasOverlap([first], second)).toBe(true);
+  });
+});

--- a/apps/project-editor/src/core/__tests__/serialization.test.ts
+++ b/apps/project-editor/src/core/__tests__/serialization.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { deserializeProject, serializeProject } from '../serialization';
+import type { Project } from '../../domain/types';
+
+const project: Project = {
+  id: 'project-1',
+  nombre: 'Evento',
+  notas: 'Notas',
+  fechas: { inicio: new Date('2024-03-01T00:00:00Z').toISOString(), fin: new Date('2024-03-02T00:00:00Z').toISOString() },
+  ubicaciones: [{ id: 'l1', nombre: 'Sala A' }],
+  cliente: { id: 'cliente-1', nombre: 'Cliente', rol: 'CLIENTE' },
+  staff: [],
+  tareas: [],
+  sesiones: [],
+  materiales: [],
+  creadoAt: new Date().toISOString(),
+  actualizadoAt: new Date().toISOString(),
+  schemaVersion: 1
+};
+
+describe('serialization', () => {
+  it('roundtrips project data without loss', () => {
+    const json = serializeProject(project);
+    const parsed = deserializeProject(json);
+    expect(parsed).toEqual(project);
+  });
+});

--- a/apps/project-editor/src/core/materials.ts
+++ b/apps/project-editor/src/core/materials.ts
@@ -1,0 +1,82 @@
+import type { Project } from '../domain/types';
+
+export interface MaterialAggregationRow {
+  materialId: string;
+  nombre: string;
+  unidad: string;
+  cantidadTotal: number;
+  porPersona: Array<{
+    ownerId: string;
+    ownerRol: 'CLIENTE' | 'STAFF';
+    ownerNombre: string;
+    cantidad: number;
+  }>;
+}
+
+export interface MaterialAggregationResult {
+  resumen: MaterialAggregationRow[];
+}
+
+export const aggregateMaterials = (project: Project): MaterialAggregationResult => {
+  const materialCatalog = new Map(project.materiales.map((material) => [material.id, material]));
+  const ownerCatalog = new Map<string, { nombre: string; rol: 'CLIENTE' | 'STAFF' }>();
+  if (project.cliente) {
+    ownerCatalog.set(project.cliente.id, { nombre: project.cliente.nombre, rol: 'CLIENTE' });
+  }
+  project.staff.forEach((persona) => ownerCatalog.set(persona.id, { nombre: persona.nombre, rol: 'STAFF' }));
+
+  const rows = new Map<string, MaterialAggregationRow>();
+
+  project.sesiones.forEach((session) => {
+    const owner = ownerCatalog.get(session.ownerId);
+    if (!owner) return;
+    session.materiales?.forEach((materialQty) => {
+      const catalogEntry = materialCatalog.get(materialQty.materialId);
+      const nombre = catalogEntry?.nombre ?? 'Material sin nombre';
+      const unidad = catalogEntry?.unidad ?? '';
+      const existing = rows.get(materialQty.materialId) ?? {
+        materialId: materialQty.materialId,
+        nombre,
+        unidad,
+        cantidadTotal: 0,
+        porPersona: [] as MaterialAggregationRow['porPersona']
+      };
+      existing.cantidadTotal += materialQty.cantidad;
+      const personaRow = existing.porPersona.find((row) => row.ownerId === session.ownerId);
+      if (personaRow) {
+        personaRow.cantidad += materialQty.cantidad;
+      } else {
+        existing.porPersona.push({
+          ownerId: session.ownerId,
+          ownerRol: owner.rol,
+          ownerNombre: owner.nombre,
+          cantidad: materialQty.cantidad
+        });
+      }
+      rows.set(materialQty.materialId, existing);
+    });
+  });
+
+  return { resumen: Array.from(rows.values()) };
+};
+
+export const materialsToCSV = (aggregation: MaterialAggregationResult): string => {
+  const header = ['Material', 'Unidad', 'Total', 'Persona', 'Rol', 'Cantidad'];
+  const lines = [header.join(',')];
+  aggregation.resumen.forEach((row) => {
+    if (row.porPersona.length === 0) {
+      lines.push([row.nombre, row.unidad, String(row.cantidadTotal), '', '', '0'].join(','));
+    }
+    row.porPersona.forEach((persona) => {
+      lines.push([
+        row.nombre,
+        row.unidad,
+        String(row.cantidadTotal),
+        persona.ownerNombre,
+        persona.ownerRol,
+        String(persona.cantidad)
+      ].join(','));
+    });
+  });
+  return lines.join('\n');
+};

--- a/apps/project-editor/src/core/project.ts
+++ b/apps/project-editor/src/core/project.ts
@@ -1,0 +1,40 @@
+import { nowISO } from '../adapters/datetime';
+import { createId } from '../adapters/uuid';
+import type { Person, Project } from '../domain/types';
+import { schemaVersion } from '../domain/types';
+
+export const createEmptyProject = (nombre: string, inicio: string, fin: string): Project => {
+  const id = createId();
+  const cliente: Person = {
+    id: createId(),
+    nombre: 'Cliente principal',
+    rol: 'CLIENTE'
+  };
+
+  const timestamp = nowISO();
+
+  return {
+    id,
+    nombre,
+    notas: '',
+    fechas: { inicio, fin },
+    ubicaciones: [],
+    cliente,
+    staff: [],
+    tareas: [],
+    sesiones: [],
+    materiales: [],
+    creadoAt: timestamp,
+    actualizadoAt: timestamp,
+    schemaVersion
+  };
+};
+
+export const touchProject = (project: Project): Project => ({
+  ...project,
+  actualizadoAt: nowISO()
+});
+
+export const updateProjectCore = <T extends Partial<Project>>(project: Project, patch: T): Project => (
+  touchProject({ ...project, ...patch })
+);

--- a/apps/project-editor/src/core/schedule.ts
+++ b/apps/project-editor/src/core/schedule.ts
@@ -1,0 +1,85 @@
+import { addMinutesToISO, minutesBetween } from '../adapters/datetime';
+import { createId } from '../adapters/uuid';
+import type { MaterialQty, Session } from '../domain/types';
+
+type OwnerRol = Session['ownerRol'];
+
+export interface SequentialConfig {
+  startISO: string;
+  durations: number[];
+  ownerId: string;
+  ownerRol: OwnerRol;
+  base?: {
+    locationId?: string;
+    tareaId?: string;
+    materiales?: MaterialQty[];
+    infoExtra?: string;
+  };
+}
+
+export const createSequentialSessions = ({
+  startISO,
+  durations,
+  ownerId,
+  ownerRol,
+  base
+}: SequentialConfig): Session[] => {
+  let cursor = startISO;
+  return durations.map((duration) => {
+    const end = addMinutesToISO(cursor, duration);
+    const session: Session = {
+      id: createId(),
+      ownerId,
+      ownerRol,
+      inicioISO: cursor,
+      finISO: end,
+      locationId: base?.locationId,
+      tareaId: base?.tareaId,
+      materiales: base?.materiales ? base.materiales.map((m) => ({ ...m })) : undefined,
+      infoExtra: base?.infoExtra
+    };
+    cursor = end;
+    return session;
+  });
+};
+
+export const sessionsOverlap = (a: Session, b: Session) => {
+  if (a.id === b.id) return false;
+  return a.inicioISO < b.finISO && b.inicioISO < a.finISO;
+};
+
+export const ownerHasOverlap = (sessions: Session[], session: Session): boolean =>
+  sessions.filter((s) => s.ownerId === session.ownerId && s.ownerRol === session.ownerRol)
+    .some((existing) => sessionsOverlap(existing, session));
+
+export const shiftSession = (session: Session, minutes: number): Session => ({
+  ...session,
+  inicioISO: addMinutesToISO(session.inicioISO, minutes),
+  finISO: addMinutesToISO(session.finISO, minutes)
+});
+
+export const updateSessionDuration = (session: Session, newDurationMinutes: number): Session => ({
+  ...session,
+  finISO: addMinutesToISO(session.inicioISO, newDurationMinutes)
+});
+
+export const sortSessions = (sessions: Session[]): Session[] =>
+  [...sessions].sort((a, b) => (a.inicioISO < b.inicioISO ? -1 : 1));
+
+export const ownerScheduleSummary = (sessions: Session[], ownerId: string) => {
+  const ownerSessions = sessions.filter((s) => s.ownerId === ownerId);
+  if (ownerSessions.length === 0) {
+    return { totalMinutes: 0, count: 0 };
+  }
+  const totalMinutes = ownerSessions.reduce((acc, session) => acc + minutesBetween(session.inicioISO, session.finISO), 0);
+  return {
+    totalMinutes,
+    count: ownerSessions.length
+  };
+};
+
+export const replaceSession = (sessions: Session[], updated: Session): Session[] =>
+  sessions.map((session) => (session.id === updated.id ? updated : session));
+
+export const removeSessionById = (sessions: Session[], id: string): Session[] =>
+  sessions.filter((session) => session.id !== id);

--- a/apps/project-editor/src/core/serialization.ts
+++ b/apps/project-editor/src/core/serialization.ts
@@ -1,0 +1,9 @@
+import { validateProject } from '../domain/types';
+import type { Project } from '../domain/types';
+
+export const serializeProject = (project: Project): string => JSON.stringify(project, null, 2);
+
+export const deserializeProject = (contents: string): Project => {
+  const parsed = JSON.parse(contents);
+  return validateProject(parsed);
+};

--- a/apps/project-editor/src/core/simulation.ts
+++ b/apps/project-editor/src/core/simulation.ts
@@ -1,0 +1,101 @@
+import { parseDate } from '../adapters/datetime';
+import type { Location, Project, Session } from '../domain/types';
+
+export interface Point {
+  x: number;
+  y: number;
+}
+
+const normalizeLatLng = (locations: Location[]): Map<string, Point> => {
+  const latitudes = locations.map((loc) => loc.lat ?? 0);
+  const longitudes = locations.map((loc) => loc.lng ?? 0);
+  const minLat = Math.min(...latitudes);
+  const maxLat = Math.max(...latitudes);
+  const minLng = Math.min(...longitudes);
+  const maxLng = Math.max(...longitudes);
+  const latRange = maxLat - minLat || 1;
+  const lngRange = maxLng - minLng || 1;
+
+  const layout = new Map<string, Point>();
+  locations.forEach((loc, index) => {
+    if (loc.lat !== undefined && loc.lng !== undefined) {
+      const x = (loc.lng - minLng) / lngRange;
+      const y = 1 - (loc.lat - minLat) / latRange;
+      layout.set(loc.id, { x, y });
+    } else {
+      const angle = (index / Math.max(1, locations.length)) * Math.PI * 2;
+      const radius = 0.3 + (index % 5) * 0.1;
+      layout.set(loc.id, {
+        x: 0.5 + radius * Math.cos(angle),
+        y: 0.5 + radius * Math.sin(angle)
+      });
+    }
+  });
+  return layout;
+};
+
+export const buildLocationLayout = (project: Project): Map<string, Point> => {
+  if (project.ubicaciones.length === 0) {
+    return new Map();
+  }
+  return normalizeLatLng(project.ubicaciones);
+};
+
+const toMillis = (iso: string) => parseDate(iso).getTime();
+
+const interpolate = (a: Point, b: Point, ratio: number): Point => ({
+  x: a.x + (b.x - a.x) * ratio,
+  y: a.y + (b.y - a.y) * ratio
+});
+
+const getSessionLocation = (session: Session, layout: Map<string, Point>): Point | null => {
+  if (!session.locationId) return null;
+  return layout.get(session.locationId) ?? null;
+};
+
+export const getOwnerPositionAt = (
+  sessions: Session[],
+  layout: Map<string, Point>,
+  timestampISO: string
+): Point | null => {
+  const time = toMillis(timestampISO);
+  const sorted = [...sessions].sort((a, b) => (a.inicioISO < b.inicioISO ? -1 : 1));
+  if (sorted.length === 0) {
+    return null;
+  }
+  for (let i = 0; i < sorted.length; i++) {
+    const session = sorted[i];
+    const start = toMillis(session.inicioISO);
+    const end = toMillis(session.finISO);
+    if (time >= start && time <= end) {
+      return getSessionLocation(session, layout);
+    }
+    if (time < start) {
+      const prev = sorted[i - 1];
+      if (prev) {
+        const prevPos = getSessionLocation(prev, layout);
+        const nextPos = getSessionLocation(session, layout);
+        if (prevPos && nextPos) {
+          const travelStart = toMillis(prev.finISO);
+          const travelDuration = start - travelStart;
+          if (travelDuration > 0) {
+            const ratio = (time - travelStart) / travelDuration;
+            if (ratio >= 0 && ratio <= 1) {
+              return interpolate(prevPos, nextPos, ratio);
+            }
+          }
+        }
+        return prevPos ?? nextPos;
+      }
+      return getSessionLocation(session, layout);
+    }
+  }
+  const last = sorted[sorted.length - 1];
+  return getSessionLocation(last, layout);
+};
+
+export const getTimelineBounds = (project: Project): { inicio: string; fin: string } | null => {
+  if (project.sesiones.length === 0) return null;
+  const sorted = [...project.sesiones].sort((a, b) => (a.inicioISO < b.inicioISO ? -1 : 1));
+  return { inicio: sorted[0].inicioISO, fin: sorted[sorted.length - 1].finISO };
+};

--- a/apps/project-editor/src/domain/types.ts
+++ b/apps/project-editor/src/domain/types.ts
@@ -1,0 +1,77 @@
+import { z } from 'zod';
+
+export const schemaVersion = 1;
+
+export const MaterialQtySchema = z.object({
+  materialId: z.string().min(1),
+  cantidad: z.number().min(0)
+});
+
+export const MaterialTypeSchema = z.object({
+  id: z.string().min(1),
+  nombre: z.string().min(1),
+  unidad: z.string().min(1)
+});
+
+export const LocationSchema = z.object({
+  id: z.string().min(1),
+  nombre: z.string().min(1),
+  lat: z.number().optional(),
+  lng: z.number().optional()
+});
+
+export const PersonSchema = z.object({
+  id: z.string().min(1),
+  nombre: z.string().min(1),
+  email: z.string().email().optional(),
+  telefono: z.string().optional(),
+  rol: z.enum(['CLIENTE', 'STAFF'])
+});
+
+export const TaskTypeSchema = z.object({
+  id: z.string().min(1),
+  nombre: z.string().min(1),
+  requiereSubtareas: z.boolean().optional(),
+  defaultMaterials: z.array(MaterialQtySchema).optional()
+});
+
+export const SessionSchema = z.object({
+  id: z.string().min(1),
+  ownerId: z.string().min(1),
+  ownerRol: z.enum(['CLIENTE', 'STAFF']),
+  inicioISO: z.string().min(1),
+  finISO: z.string().min(1),
+  locationId: z.string().optional(),
+  tareaId: z.string().optional(),
+  materiales: z.array(MaterialQtySchema).optional(),
+  infoExtra: z.string().optional()
+});
+
+export const ProjectSchema = z.object({
+  id: z.string().min(1),
+  nombre: z.string().min(1),
+  notas: z.string().optional(),
+  fechas: z.object({
+    inicio: z.string().min(1),
+    fin: z.string().min(1)
+  }),
+  ubicaciones: z.array(LocationSchema),
+  cliente: PersonSchema.optional(),
+  staff: z.array(PersonSchema),
+  tareas: z.array(TaskTypeSchema),
+  sesiones: z.array(SessionSchema),
+  materiales: z.array(MaterialTypeSchema),
+  creadoAt: z.string().min(1),
+  actualizadoAt: z.string().min(1),
+  schemaVersion: z.literal(schemaVersion)
+});
+
+export type MaterialQty = z.infer<typeof MaterialQtySchema>;
+export type MaterialType = z.infer<typeof MaterialTypeSchema>;
+export type Location = z.infer<typeof LocationSchema>;
+export type Person = z.infer<typeof PersonSchema>;
+export type TaskType = z.infer<typeof TaskTypeSchema>;
+export type Session = z.infer<typeof SessionSchema>;
+export type Project = z.infer<typeof ProjectSchema>;
+
+export const validateProject = (input: unknown): Project => ProjectSchema.parse(input);

--- a/apps/project-editor/src/hooks/useKeyboardShortcuts.ts
+++ b/apps/project-editor/src/hooks/useKeyboardShortcuts.ts
@@ -1,0 +1,44 @@
+import { useEffect } from 'react';
+
+interface Handlers {
+  onSave?: () => void;
+  onOpen?: () => void;
+  onNew?: () => void;
+  onTogglePlay?: () => void;
+  onZoomIn?: () => void;
+  onZoomOut?: () => void;
+}
+
+export const useKeyboardShortcuts = (handlers: Handlers) => {
+  useEffect(() => {
+    const listener = (event: KeyboardEvent) => {
+      const isCtrl = event.ctrlKey || event.metaKey;
+      if (isCtrl && event.key.toLowerCase() === 's') {
+        event.preventDefault();
+        handlers.onSave?.();
+      }
+      if (isCtrl && event.key.toLowerCase() === 'o') {
+        event.preventDefault();
+        handlers.onOpen?.();
+      }
+      if (isCtrl && event.key.toLowerCase() === 'n') {
+        event.preventDefault();
+        handlers.onNew?.();
+      }
+      if (event.code === 'Space') {
+        event.preventDefault();
+        handlers.onTogglePlay?.();
+      }
+      if (event.key === '+' || event.key === '=') {
+        event.preventDefault();
+        handlers.onZoomIn?.();
+      }
+      if (event.key === '-' || event.key === '_') {
+        event.preventDefault();
+        handlers.onZoomOut?.();
+      }
+    };
+    window.addEventListener('keydown', listener);
+    return () => window.removeEventListener('keydown', listener);
+  }, [handlers]);
+};

--- a/apps/project-editor/src/main.tsx
+++ b/apps/project-editor/src/main.tsx
@@ -1,0 +1,21 @@
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+import './App.css';
+
+declare global {
+  interface WindowEventMap {
+    'project-editor:new-project': CustomEvent;
+  }
+}
+
+const rootElement = document.getElementById('root');
+if (!rootElement) {
+  throw new Error('No se encontró el elemento raíz');
+}
+
+createRoot(rootElement).render(
+  <StrictMode>
+    <App />
+  </StrictMode>
+);

--- a/apps/project-editor/src/setupTests.ts
+++ b/apps/project-editor/src/setupTests.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';

--- a/apps/project-editor/src/state/projectStore.ts
+++ b/apps/project-editor/src/state/projectStore.ts
@@ -1,0 +1,274 @@
+import { createStore } from '../adapters/state/store';
+import { writeAutosave, readAutosave, clearAutosave } from '../adapters/storage/local';
+import { createId } from '../adapters/uuid';
+import type {
+  Location,
+  MaterialQty,
+  MaterialType,
+  Person,
+  Project,
+  Session,
+  TaskType
+} from '../domain/types';
+import { createEmptyProject, touchProject, updateProjectCore } from '../core/project';
+import {
+  createSequentialSessions,
+  ownerHasOverlap,
+  removeSessionById,
+  replaceSession,
+  sortSessions,
+  shiftSession as shiftSessionCore,
+  updateSessionDuration
+} from '../core/schedule';
+import { deserializeProject, serializeProject } from '../core/serialization';
+
+interface ProjectState {
+  project: Project | null;
+  autosaveLoaded: boolean;
+  hasUnsavedChanges: boolean;
+  lastSavedAt: string | null;
+  lastError: string | null;
+  createProject: (payload: { nombre: string; inicio: string; fin: string }) => void;
+  loadProject: (project: Project) => void;
+  markSaved: () => void;
+  resetProject: () => void;
+  addLocation: (input: Omit<Location, 'id'> & { id?: string }) => Location | null;
+  addTaskType: (input: Omit<TaskType, 'id'> & { id?: string }) => TaskType | null;
+  addMaterialType: (input: Omit<MaterialType, 'id'> & { id?: string }) => MaterialType | null;
+  addStaffMember: (input: Omit<Person, 'id' | 'rol'> & { id?: string }) => Person | null;
+  updateCliente: (input: Partial<Person>) => void;
+  updateProjectDetails: (input: {
+    nombre?: string;
+    notas?: string | null;
+    fechas?: { inicio: string; fin: string };
+  }) => void;
+  appendSequentialSessions: (payload: {
+    startISO: string;
+    durations: number[];
+    ownerId: string;
+    ownerRol: Session['ownerRol'];
+  }) => Session[];
+  updateSession: (sessionId: string, changes: Partial<Session>) => Session | null;
+  shiftSession: (sessionId: string, minutes: number) => Session | null;
+  changeSessionDuration: (sessionId: string, minutes: number) => Session | null;
+  removeSession: (sessionId: string) => void;
+  setSessionMaterials: (sessionId: string, materials: MaterialQty[]) => Session | null;
+}
+
+const loadAutosaveProject = (): Project | null => {
+  try {
+    const raw = readAutosave();
+    if (!raw) return null;
+    return deserializeProject(raw);
+  } catch (error) {
+    console.warn('No se pudo cargar el autosave', error);
+    return null;
+  }
+};
+
+export const useProjectStore = createStore<ProjectState>((set, get) => {
+  const autosavedProject = loadAutosaveProject();
+  return {
+    project: autosavedProject,
+    autosaveLoaded: Boolean(autosavedProject),
+    hasUnsavedChanges: false,
+    lastSavedAt: null,
+    lastError: null,
+    createProject: ({ nombre, inicio, fin }) => {
+      const project = createEmptyProject(nombre, inicio, fin);
+      clearAutosave();
+      set({ project, hasUnsavedChanges: true, lastError: null, autosaveLoaded: false });
+    },
+    loadProject: (project) => {
+      clearAutosave();
+      set({ project, hasUnsavedChanges: false, lastSavedAt: null, lastError: null, autosaveLoaded: false });
+    },
+    markSaved: () => {
+      set({ hasUnsavedChanges: false, lastSavedAt: new Date().toISOString() });
+    },
+    resetProject: () => {
+      clearAutosave();
+      set({ project: null, hasUnsavedChanges: false, lastSavedAt: null, autosaveLoaded: false });
+    },
+    addLocation: (input) => {
+      const state = get();
+      if (!state.project) return null;
+      const newLocation: Location = {
+        id: input.id ?? createId(),
+        nombre: input.nombre,
+        lat: input.lat,
+        lng: input.lng
+      };
+      const exists = state.project.ubicaciones.some((loc) => loc.nombre === newLocation.nombre);
+      if (exists) {
+        set({ lastError: 'Ya existe una ubicación con ese nombre' });
+        return null;
+      }
+      const project = updateProjectCore(state.project, {
+        ubicaciones: [...state.project.ubicaciones, newLocation]
+      });
+      set({ project, hasUnsavedChanges: true, lastError: null });
+      return newLocation;
+    },
+    addTaskType: (input) => {
+      const state = get();
+      if (!state.project) return null;
+      const newTask: TaskType = {
+        id: input.id ?? createId(),
+        nombre: input.nombre,
+        requiereSubtareas: input.requiereSubtareas,
+        defaultMaterials: input.defaultMaterials?.map((m) => ({ ...m }))
+      };
+      const exists = state.project.tareas.some((task) => task.nombre === newTask.nombre);
+      if (exists) {
+        set({ lastError: 'Ya existe una tarea con ese nombre' });
+        return null;
+      }
+      const project = updateProjectCore(state.project, {
+        tareas: [...state.project.tareas, newTask]
+      });
+      set({ project, hasUnsavedChanges: true, lastError: null });
+      return newTask;
+    },
+    addMaterialType: (input) => {
+      const state = get();
+      if (!state.project) return null;
+      const newMaterial: MaterialType = {
+        id: input.id ?? createId(),
+        nombre: input.nombre,
+        unidad: input.unidad
+      };
+      const exists = state.project.materiales.some((material) => material.nombre === newMaterial.nombre);
+      if (exists) {
+        set({ lastError: 'Ya existe un material con ese nombre' });
+        return null;
+      }
+      const project = updateProjectCore(state.project, {
+        materiales: [...state.project.materiales, newMaterial]
+      });
+      set({ project, hasUnsavedChanges: true, lastError: null });
+      return newMaterial;
+    },
+    addStaffMember: (input) => {
+      const state = get();
+      if (!state.project) return null;
+      const newStaff: Person = {
+        id: input.id ?? createId(),
+        nombre: input.nombre,
+        email: input.email,
+        telefono: input.telefono,
+        rol: 'STAFF'
+      };
+      const project = updateProjectCore(state.project, {
+        staff: [...state.project.staff, newStaff]
+      });
+      set({ project, hasUnsavedChanges: true, lastError: null });
+      return newStaff;
+    },
+    updateCliente: (input) => {
+      const state = get();
+      if (!state.project) return;
+      const existing = state.project.cliente;
+      const cliente: Person = existing
+        ? { ...existing, ...input, rol: 'CLIENTE' }
+        : {
+            id: createId(),
+            nombre: input.nombre ?? 'Cliente',
+            email: input.email,
+            telefono: input.telefono,
+            rol: 'CLIENTE'
+          };
+      const project = updateProjectCore(state.project, { cliente });
+      set({ project, hasUnsavedChanges: true, lastError: null });
+    },
+    updateProjectDetails: (input) => {
+      const state = get();
+      if (!state.project) return;
+      const project = updateProjectCore(state.project, {
+        nombre: input.nombre ?? state.project.nombre,
+        notas: input.notas ?? state.project.notas,
+        fechas: input.fechas ?? state.project.fechas
+      });
+      set({ project, hasUnsavedChanges: true, lastError: null });
+    },
+    appendSequentialSessions: ({ startISO, durations, ownerId, ownerRol }) => {
+      const state = get();
+      if (!state.project) return [];
+      const newSessions = createSequentialSessions({ startISO, durations, ownerId, ownerRol });
+      const combined = [...state.project.sesiones];
+      for (const session of newSessions) {
+        if (ownerHasOverlap(combined, session)) {
+          set({ lastError: 'Los segmentos se solapan con el horario existente' });
+          return [];
+        }
+        combined.push(session);
+      }
+      const project = touchProject({
+        ...state.project,
+        sesiones: sortSessions(combined)
+      });
+      set({ project, hasUnsavedChanges: true, lastError: null });
+      return newSessions;
+    },
+    updateSession: (sessionId, changes) => {
+      const state = get();
+      if (!state.project) return null;
+      const target = state.project.sesiones.find((session) => session.id === sessionId);
+      if (!target) return null;
+      const updated: Session = {
+        ...target,
+        ...changes,
+        materiales: changes.materiales ?? target.materiales
+      };
+      const others = state.project.sesiones.filter((session) => session.id !== sessionId);
+      if (ownerHasOverlap(others, updated)) {
+        set({ lastError: 'El segmento se solapa con otro existente' });
+        return null;
+      }
+      const project = touchProject({
+        ...state.project,
+        sesiones: sortSessions(replaceSession(state.project.sesiones, updated))
+      });
+      set({ project, hasUnsavedChanges: true, lastError: null });
+      return updated;
+    },
+    shiftSession: (sessionId, minutes) => {
+      const state = get();
+      if (!state.project) return null;
+      const target = state.project.sesiones.find((session) => session.id === sessionId);
+      if (!target) return null;
+      const shifted = shiftSessionCore(target, minutes);
+      return get().updateSession(sessionId, shifted);
+    },
+    changeSessionDuration: (sessionId, minutes) => {
+      const state = get();
+      if (!state.project) return null;
+      const target = state.project.sesiones.find((session) => session.id === sessionId);
+      if (!target) return null;
+      const updated = updateSessionDuration(target, minutes);
+      return get().updateSession(sessionId, updated);
+    },
+    removeSession: (sessionId) => {
+      const state = get();
+      if (!state.project) return;
+      const project = touchProject({
+        ...state.project,
+        sesiones: removeSessionById(state.project.sesiones, sessionId)
+      });
+      set({ project, hasUnsavedChanges: true, lastError: null });
+    },
+    setSessionMaterials: (sessionId, materials) => {
+      const state = get();
+      if (!state.project) return null;
+      return get().updateSession(sessionId, { materiales: materials });
+    }
+  };
+});
+
+useProjectStore.subscribe((state) => {
+  if (!state.project) {
+    clearAutosave();
+    return;
+  }
+  writeAutosave(serializeProject(state.project));
+});

--- a/apps/project-editor/src/utils/time.ts
+++ b/apps/project-editor/src/utils/time.ts
@@ -1,0 +1,9 @@
+export const toDateInputValue = (iso: string) => iso.slice(0, 10);
+
+export const toTimeInputValue = (iso: string) => iso.slice(11, 16);
+
+export const fromDateTimeInputs = (date: string, time: string) => {
+  return new Date(`${date}T${time}:00`).toISOString();
+};
+
+export const minutesOptions = [5, 15, 30, 60];

--- a/apps/project-editor/tsconfig.json
+++ b/apps/project-editor/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "moduleResolution": "Node",
+    "strict": true,
+    "jsx": "react-jsx",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["vitest/globals", "@testing-library/jest-dom"]
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/apps/project-editor/tsconfig.node.json
+++ b/apps/project-editor/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/apps/project-editor/vite.config.ts
+++ b/apps/project-editor/vite.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    open: false
+  },
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: './src/setupTests.ts'
+  }
+});


### PR DESCRIPTION
## Summary
- keep the formulario local state in sync with the loaded proyecto and bootstrap a cliente when falta en el JSON importado
- ensure the editor de horarios actualiza campos específicos de forma segura y reutiliza el nuevo material creado en la misma acción
- autoactiva nuevos propietarios en la vista Gantt para que el staff añadido se muestre sin pasos adicionales

## Testing
- `npm run validate` *(falla: faltan dependencias porque el registro de npm devuelve 403 y `tsc` no encuentra los tipos de testing)*

------
https://chatgpt.com/codex/tasks/task_e_68cfc1f3375c832aa198482d04e9adbd