### PR TITLE
Handle empty base date/time values in schedule editor

### DIFF
--- a/apps/project-editor/src/components/ScheduleEditor.tsx
+++ b/apps/project-editor/src/components/ScheduleEditor.tsx
@@ -37,7 +37,9 @@ export const ScheduleEditor: FC<Props> = ({ ownerId, ownerRol, ownerNombre }) =>
   }
 
   const handleDurationClick = (minutes: number) => {
-    if (!fechaBase) return;
+    if (!fechaBase || !horaBase) {
+      return;
+    }
     const startISO = nextStart || fromDateTimeInputs(fechaBase, horaBase);
     const sessions = appendSequentialSessions({ startISO, durations: [minutes], ownerId, ownerRol });
     if (sessions.length > 0) {
@@ -109,10 +111,19 @@ export const ScheduleEditor: FC<Props> = ({ ownerId, ownerRol, ownerNombre }) =>
         <div className="controls-row" role="group" aria-label="Configuración de inicio">
           <label>
             Fecha base
-            <input type="date" value={fechaBase} onChange={(event) => {
-              setFechaBase(event.target.value);
-              setNextStart(fromDateTimeInputs(event.target.value, horaBase));
-            }} />
+            <input
+              type="date"
+              value={fechaBase}
+              onChange={(event) => {
+                const value = event.target.value;
+                setFechaBase(value);
+                if (value && horaBase) {
+                  setNextStart(fromDateTimeInputs(value, horaBase));
+                } else {
+                  setNextStart('');
+                }
+              }}
+            />
           </label>
           <label>
             Hora inicial
@@ -120,8 +131,13 @@ export const ScheduleEditor: FC<Props> = ({ ownerId, ownerRol, ownerNombre }) =>
               type="time"
               value={horaBase}
               onChange={(event) => {
-                setHoraBase(event.target.value);
-                setNextStart(fromDateTimeInputs(fechaBase, event.target.value));
+                const value = event.target.value;
+                setHoraBase(value);
+                if (fechaBase && value) {
+                  setNextStart(fromDateTimeInputs(fechaBase, value));
+                } else {
+                  setNextStart('');
+                }
               }}
             />
           </label>

--- a/apps/project-editor/src/components/__tests__/app-flow.test.tsx
+++ b/apps/project-editor/src/components/__tests__/app-flow.test.tsx
@@ -60,4 +60,29 @@ describe('flujo completo del asistente', () => {
     await user.click(screen.getByRole('button', { name: 'Guardar como…' }));
     expect(downloadFile).toHaveBeenCalled();
   });
+
+  it('permite limpiar y restablecer la fecha base y hora inicial sin errores', async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    await user.click(screen.getByText('Nuevo', { selector: 'button' }));
+
+    await user.click(screen.getByRole('button', { name: 'Cliente', selector: 'button' }));
+
+    const schedule = await screen.findByLabelText('Horario de Cliente principal');
+    const dateInput = within(schedule).getByLabelText('Fecha base');
+    const timeInput = within(schedule).getByLabelText('Hora inicial');
+
+    await user.clear(dateInput);
+    await user.clear(timeInput);
+
+    await user.type(dateInput, '2024-05-01');
+    await user.type(timeInput, '10:30');
+
+    const addButton = within(schedule).getAllByText('+15 min')[0];
+    await user.click(addButton);
+
+    const deleteButtons = await within(schedule).findAllByRole('button', { name: 'Eliminar' });
+    expect(deleteButtons.length).toBeGreaterThan(0);
+  });
 });


### PR DESCRIPTION
## Summary
- prevent ScheduleEditor from recalculating the next start time when either the base date or time inputs are empty
- guard duration generation until both date and time are defined to avoid producing invalid ISO strings
- add a regression test covering clearing and restoring the base date/time without triggering exceptions

## Testing
- npm test *(fails: vitest binary unavailable before installing dependencies; npm install blocked by 403 from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68cfc9df04d8832aaa67a1f43f63d5fa